### PR TITLE
Add "open" alias

### DIFF
--- a/blobfile/__init__.py
+++ b/blobfile/__init__.py
@@ -17,6 +17,7 @@ from blobfile.ops import (
     md5,
     set_log_callback,
     BlobFile,
+    BlobFile as open,
     LocalBlobFile,
 )
 from blobfile.common import Request, Error, RequestFailure


### PR DESCRIPTION
Maybe this is bad since `open` is a builtin, but if legal it's a nice alias