### PR TITLE
bf.copy: fix cloud copy in GCS

### DIFF
--- a/blobfile/ops.py
+++ b/blobfile/ops.py
@@ -740,8 +740,8 @@ def copy(
     if _is_google_path(src) and _is_google_path(dst):
         srcbucket, srcname = google.split_url(src)
         dstbucket, dstname = google.split_url(dst)
+        params = {}
         while True:
-            params = {}
             req = Request(
                 url=google.build_url(
                     "/storage/v1/b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}",


### PR DESCRIPTION
It looks like most calls return in a single RPC, but e.g. copying across
different storage classes was probably broken.