### PR TITLE
_azure_get_storage_account_key: [minor] simplify control flow

### DIFF
--- a/blobfile/ops.py
+++ b/blobfile/ops.py
@@ -440,10 +440,9 @@ def _azure_get_storage_account_key(
                     raise Error(
                         f"Found storage account key, but it was unable to access storage account: '{account}'"
                     )
-        else:
-            raise Error(
-                f"Storage account was found, but storage account keys were missing: '{account}'"
-            )
+        raise Error(
+            f"Storage account was found, but storage account keys were missing: '{account}'"
+        )
     return None
 
 


### PR DESCRIPTION
The loop doesn't break, so the else clause will always execute. I
tripped over this a little while reading it, so thought I'd make the
small change.