### PR TITLE
use cached az subscriptions, look at default first

### DIFF
--- a/blobfile/azure.py
+++ b/blobfile/azure.py
@@ -7,7 +7,7 @@ import datetime
 import time
 import calendar
 import re
-from typing import Mapping, Tuple, Sequence
+from typing import Any, Mapping, Tuple, Sequence
 
 import xmltodict
 
@@ -19,7 +19,7 @@ OAUTH_TOKEN = "oauth_token"
 ANONYMOUS = "anonymous"
 
 
-def load_credentials() -> Mapping[str, str]:
+def load_credentials() -> Mapping[str, Any]:
     # https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity#environment-variables
     # AZURE_STORAGE_KEY seems to be the environment variable mentioned by the az cli
     # AZURE_STORAGE_ACCOUNT_KEY is mentioned elsewhere on the internet
@@ -67,7 +67,9 @@ def load_credentials() -> Mapping[str, str]:
         with open(default_profile_path, "rb") as f:
             # this file has a UTF-8 BOM
             profile = json.loads(f.read().decode("utf-8-sig"))
-            subscriptions = [sub["id"] for sub in profile["subscriptions"]]
+        subscriptions = profile["subscriptions"]
+        subscriptions.sort(key=lambda x: x["isDefault"], reverse=True)
+        subscriptions = [sub["id"] for sub in subscriptions]
 
         with open(default_creds_path) as f:
             tokens = json.load(f)

--- a/blobfile/ops.py
+++ b/blobfile/ops.py
@@ -363,18 +363,21 @@ def _azure_get_storage_account_key(
     result = json.loads(resp.data)
     auth = (azure.OAUTH_TOKEN, result["access_token"])
 
-    # get a list of subscriptions so we can query each one for storage accounts
-    def build_req() -> Request:
-        req = Request(
-            method="GET",
-            url="https://management.azure.com/subscriptions",
-            params={"api-version": "2020-01-01"},
-        )
-        return azure.make_api_request(req, auth=auth)
+    if "subscriptions" in creds:
+        subscription_ids = creds["subscriptions"]
+    else:
+        # get a list of subscriptions so we can query each one for storage accounts
+        def build_req() -> Request:
+            req = Request(
+                method="GET",
+                url="https://management.azure.com/subscriptions",
+                params={"api-version": "2020-01-01"},
+            )
+            return azure.make_api_request(req, auth=auth)
 
-    resp = _execute_request(build_req)
-    result = json.loads(resp.data)
-    subscription_ids = [item["subscriptionId"] for item in result["value"]]
+        resp = _execute_request(build_req)
+        result = json.loads(resp.data)
+        subscription_ids = [item["subscriptionId"] for item in result["value"]]
 
     for subscription_id in subscription_ids:
         # get a list of storage accounts


### PR DESCRIPTION
The query limits for subscription seem pretty low https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling
This is causing 429s when trying to authenticate based on finding storage keys.
This PR should reduce the number of requests we make by a fair amount. We a) use azure-cli's cached subscriptions list, b) query the default subscription first