### PR TITLE
normalize paths before listing

### DIFF
--- a/blobfile/azure.py
+++ b/blobfile/azure.py
@@ -295,6 +295,10 @@ def combine_url(account: str, container: str, obj: str) -> str:
     return f"https://{account}.blob.core.windows.net/{container}/{obj}"
 
 
+def normalize_url(path: str) -> str:
+    return combine_url(*split_url_az(path))
+
+
 def sign_with_shared_key(req: Request, key: str) -> str:
     # https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
     params_to_sign = []

--- a/blobfile/ops.py
+++ b/blobfile/ops.py
@@ -1778,9 +1778,17 @@ def _get_slash_path(entry: DirEntry) -> str:
     return entry.path + "/" if entry.is_dir else entry.path
 
 
+def _normalize_path(path: str) -> str:
+    if path.startswith('az://'):
+        return azure.combine_url(*azure.split_url_az(path))
+    return path
+
+
 def _list_blobs_in_dir(prefix: str, exclude_prefix: bool) -> Iterator[DirEntry]:
-    for entry in _list_blobs(path=prefix, delimiter="/"):
-        if exclude_prefix and _get_slash_path(entry) == prefix:
+    # the prefix check doesn't work without normalization
+    normalized_prefix = _normalize_path(prefix)
+    for entry in _list_blobs(path=normalized_prefix, delimiter="/"):
+        if exclude_prefix and _get_slash_path(entry) == normalized_prefix:
             continue
         yield entry
 

--- a/blobfile/ops.py
+++ b/blobfile/ops.py
@@ -1780,7 +1780,7 @@ def _get_slash_path(entry: DirEntry) -> str:
 
 def _normalize_path(path: str) -> str:
     if path.startswith('az://'):
-        return azure.combine_url(*azure.split_url_az(path))
+        return azure.normalize_url(path)
     return path
 
 


### PR DESCRIPTION
without this normalization, the prefix check is incorrect.  this causes listdir on directories to list the directory itself