### PR TITLE
Treat 409s as a failure to access a container

### DIFF
--- a/blobfile/ops.py
+++ b/blobfile/ops.py
@@ -343,7 +343,7 @@ def _azure_can_access_container(
             method="GET",
             url=azure.build_url(account, "/{container}", container=container),
             params={"restype": "container", "comp": "list", "maxresults": "1"},
-            success_codes=(200, 403, 404, INVALID_HOSTNAME_STATUS),
+            success_codes=(200, 403, 404, 409, INVALID_HOSTNAME_STATUS),
         )
         return azure.make_api_request(req, auth=auth)
 


### PR DESCRIPTION
We run into these with anonymous access. Resolves #139