### PR TITLE
Identify provenance of storage account keys when misconfigured

### DIFF
--- a/blobfile/_ops.py
+++ b/blobfile/_ops.py
@@ -494,7 +494,8 @@ def _azure_get_access_token(key: Any) -> Tuple[Any, float]:
         if "account" in creds:
             if creds["account"] != account:
                 raise Error(
-                    f"Found credentials for account '{creds['account']}' but needed credentials for account '{account}'"
+                    f"Provided storage account key for account '{creds['account']}' via environment variables, "
+                    f"but needed credentials for account '{account}'"
                 )
         auth = (azure.SHARED_KEY, creds["storageAccountKey"])
         if _azure_can_access_container(account, container, auth):


### PR DESCRIPTION
"Found credentials" was vague. This more directly lets users who put
storage account keys in environment variables that blobfile is looking
at the keys they specified.