### PR TITLE
fix infrequent exception on Python 3.7.3

### DIFF
--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -601,8 +601,9 @@ class BaseStreamingWriteFile(io.BufferedIOBase):
         else:
             self._buf += b
             if len(self._buf) >= self._chunk_size:
-                size = self._upload_buf(memoryview(self._buf))
-                del self._buf[:size]
+                mv = memoryview(self._buf)
+                size = self._upload_buf(mv)
+                self._buf = bytearray(mv[size:])
         assert len(self._buf) < self._chunk_size
         return len(b)
 


### PR DESCRIPTION
This fixes an infrequent exception I saw when writing to a streaming `BlobFile`. It's not quite clear why this error is non-deterministic, or what causes it. My best theory is that it's a bug in Python's reference counting of bytearray objects, but I can't verify that.

```
...
  File "/opt/conda/lib/python3.7/site-packages/blobfile/_common.py", line 586, in write
    del self._buf[:size]
BufferError: Existing exports of data: object cannot be re-sized
```