### PR TITLE
Move onto Azure OAuth v2 endpoints, log reponse headers on failure

### DIFF
--- a/blobfile/_azure.py
+++ b/blobfile/_azure.py
@@ -161,7 +161,7 @@ def _create_access_token_request(
     else:
         # https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#first-case-access-token-request-with-a-shared-secret
         # https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory#use-oauth-access-tokens-for-authentication
-        # The following 
+        # The following Azure CLI commands will create an AzureAD service principal with sufficient access to use Azure's `client_credentials` grant type:
         # az ad sp create-for-rbac --name <name>
         # az account list
         # az role assignment create --role "Storage Blob Data Contributor" --assignee <app_id> --scope "/subscriptions/<subscription_id>/resourceGroups/<resource_group_name>/providers/Microsoft.Storage/storageAccounts/<storage_account_name>"

--- a/blobfile/_azure.py
+++ b/blobfile/_azure.py
@@ -160,6 +160,11 @@ def _create_access_token_request(
         tenant = "common"
     else:
         # https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#first-case-access-token-request-with-a-shared-secret
+        # https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory#use-oauth-access-tokens-for-authentication
+        # The following 
+        # az ad sp create-for-rbac --name <name>
+        # az account list
+        # az role assignment create --role "Storage Blob Data Contributor" --assignee <app_id> --scope "/subscriptions/<subscription_id>/resourceGroups/<resource_group_name>/providers/Microsoft.Storage/storageAccounts/<storage_account_name>"
         data = {
             "grant_type": "client_credentials",
             "client_id": creds["appId"],


### PR DESCRIPTION
Generally in the event of a failed request Azure's endpoints will return a correlation ID and trace ID in the response body to help isolate the root cause of the failure. However, it occasionally fails to do so. There's a secondary request identifier hidden in the response headers (`x-ms-request-id`) that can be combined with the request's timestamp to lookup relevant logs on Azure's side.

This PR moves `blobfile._azure._create_access_token_request` off of Azure's deprecated v1 OAuth API in favor of v2, and adds response headers (if any exist) to `blobfile._common.RequestFailure` exceptions.