### PR TITLE
Save access tokens to disk to allow new processes to use cached tokens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * `parallel` option to `rmtree`
 * fix trailing semicolon with `bf.join`
+* add `save_access_token_to_disk` to save local access tokens locally
 
 ## 1.2.8
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ There are a few bonus functions:
     * `get_http_pool=None`: a function that returns a `urllib3.PoolManager` to be used for requests
     * `use_streaming_read=True`: if set to `False`, read a chunk at a time instead of streaming them
     * `default_buffer_size=io.DEFAULT_BUFFER_SIZE`: the default buffer size to use for reading files (and writing local files)
-    * `save_access_token_to_disk=True`: Whether or not to save access tokens to disk.  Other processes can read the access tokens to avoid the 250ms it usually takes to get a token.
+    * `save_access_token_to_disk=False`: Whether or not to save access tokens to disk.  Other processes can read the access tokens to avoid the 250ms it usually takes to get a token.
 * `create_context` - (same arguments as `configure`), creates a new instance of `blobfile` with a custom configuration instead of modifying the global configuration
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ There are a few bonus functions:
     * `get_http_pool=None`: a function that returns a `urllib3.PoolManager` to be used for requests
     * `use_streaming_read=True`: if set to `False`, read a chunk at a time instead of streaming them
     * `default_buffer_size=io.DEFAULT_BUFFER_SIZE`: the default buffer size to use for reading files (and writing local files)
+    * `save_access_token_to_disk=True`: Whether or not to save access tokens to disk.  Other processes can read the access tokens to avoid the 250ms it usually takes to get a token.
 * `create_context` - (same arguments as `configure`), creates a new instance of `blobfile` with a custom configuration instead of modifying the global configuration
 
 ## Authentication

--- a/blobfile/_azure.py
+++ b/blobfile/_azure.py
@@ -1,39 +1,39 @@
-import binascii
-import hashlib
-import random
-import urllib.parse
-import os
-import json
-import hmac
 import base64
-import time
+import binascii
 import calendar
-import datetime
-import re
-import math
 import concurrent.futures
-from typing import Any, Mapping, Dict, Optional, Tuple, Sequence, List, Iterator
+import datetime
+import hashlib
+import hmac
+import json
+import math
+import os
+import random
+import re
+import time
+import urllib.parse
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
 
-import xmltodict
 import urllib3
+import xmltodict
 
 from blobfile import _common as common
 from blobfile._common import (
-    Request,
-    Error,
-    Stat,
-    Config,
+    DEFAULT_RETRY_CODES,
     INVALID_HOSTNAME_STATUS,
-    TokenManager,
-    ConcurrentWriteFailure,
-    RequestFailure,
     BaseStreamingReadFile,
     BaseStreamingWriteFile,
-    FileBody,
+    ConcurrentWriteFailure,
+    Config,
     DirEntry,
-    strip_slashes,
+    Error,
+    FileBody,
+    Request,
+    RequestFailure,
+    Stat,
+    TokenManager,
     path_join,
-    DEFAULT_RETRY_CODES,
+    strip_slashes,
 )
 
 SHARED_KEY = "shared_key"
@@ -1484,6 +1484,6 @@ def join_paths(conf: Config, a: str, b: str) -> str:
     return combine_path(conf, account, container, obj)
 
 
-access_token_manager = TokenManager(_get_access_token)
+access_token_manager = TokenManager(_get_access_token, "azure_access")
 
-sas_token_manager = TokenManager(_get_sas_token)
+sas_token_manager = TokenManager(_get_sas_token, "azure_sas")

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -704,8 +704,6 @@ class TokenManager:
 
     def _save_token_file(self, log_callback: Callable[[str], None]):
         os.makedirs(os.path.dirname(self._access_lock_file), exist_ok=True)
-        with open(self._access_lock_file, "w") as f:
-            f.write("")
 
         try:
             with filelock.FileLock(self._access_lock_file, timeout=1):

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -1,41 +1,42 @@
 # https://mypy.readthedocs.io/en/stable/common_issues.html#using-classes-that-are-generic-in-stubs-but-not-at-runtime
 from __future__ import annotations
-import contextlib
 
-import os
-import tempfile
+import binascii
+import collections
+import concurrent.futures
+import contextlib
+import glob as local_glob
 import hashlib
 import io
-import urllib.parse
-import time
-import binascii
-import stat as stat_module
-import glob as local_glob
-import re
-import shutil
-import collections
 import itertools
 import math
-import urllib3
-import concurrent.futures
 import multiprocessing as mp
+import os
+import re
+import shutil
+import stat as stat_module
+import tempfile
+import time
+import urllib.parse
 from types import ModuleType
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Optional,
-    Tuple,
-    Callable,
-    Sequence,
-    Iterator,
-    TextIO,
     BinaryIO,
+    Callable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    TextIO,
+    Tuple,
+    Union,
     cast,
     overload,
-    NamedTuple,
-    List,
-    Union,
-    TYPE_CHECKING,
 )
+
+import urllib3
 
 if TYPE_CHECKING:
     # Literal is only in the stdlib in Python 3.8+
@@ -45,21 +46,22 @@ if TYPE_CHECKING:
     # c) type checkers always know what typing_extensions is
     from typing_extensions import Literal
 
-
 import filelock
 
-from blobfile import _gcp as gcp, _azure as azure, _common as common
+from blobfile import _azure as azure
+from blobfile import _common as common
+from blobfile import _gcp as gcp
 from blobfile._common import (
-    Request,
-    Error,
-    RestartableStreamingWriteFailure,
-    Stat,
-    DirEntry,
-    Config,
     CHUNK_SIZE,
-    get_log_threshold_for_error,
     DEFAULT_CONNECTION_POOL_MAX_SIZE,
     DEFAULT_MAX_CONNECTION_POOL_COUNT,
+    Config,
+    DirEntry,
+    Error,
+    Request,
+    RestartableStreamingWriteFailure,
+    Stat,
+    get_log_threshold_for_error,
 )
 
 # https://cloud.google.com/storage/docs/naming
@@ -801,6 +803,7 @@ class Context:
         file_size: Optional[int] = None,
     ) -> BinaryIO:
         ...
+
     @overload
     def BlobFile(
         self,
@@ -812,6 +815,7 @@ class Context:
         file_size: Optional[int] = None,
     ) -> TextIO:
         ...
+
     def BlobFile(
         self,
         path: str,
@@ -1458,6 +1462,7 @@ def create_context(
     use_streaming_read: bool = False,
     default_buffer_size: int = DEFAULT_BUFFER_SIZE,
     get_deadline: Optional[Callable[[], float]] = None,
+    save_access_token_to_disk: bool = True,
 ):
     """
     Same argument as configure(), but returns a Context object that has all the blobfile methods on it.
@@ -1479,5 +1484,6 @@ def create_context(
         use_streaming_read=use_streaming_read,
         default_buffer_size=default_buffer_size,
         get_deadline=get_deadline,
+        save_access_token_to_disk=save_access_token_to_disk,
     )
     return Context(conf=conf)

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -1462,7 +1462,7 @@ def create_context(
     use_streaming_read: bool = False,
     default_buffer_size: int = DEFAULT_BUFFER_SIZE,
     get_deadline: Optional[Callable[[], float]] = None,
-    save_access_token_to_disk: bool = True,
+    save_access_token_to_disk: bool = False,
 ):
     """
     Same argument as configure(), but returns a Context object that has all the blobfile methods on it.

--- a/blobfile/_gcp.py
+++ b/blobfile/_gcp.py
@@ -1,38 +1,38 @@
-import urllib.parse
-import json
 import base64
-import os
-import time
-import platform
+import binascii
+import concurrent.futures
 import datetime
 import hashlib
-import socket
-import binascii
+import json
 import math
-import concurrent.futures
-from typing import Mapping, Dict, Any, Optional, Tuple, List, Iterator
+import os
+import platform
+import socket
+import time
+import urllib.parse
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple
 
-from Cryptodome.Signature import pkcs1_15
+import urllib3
 from Cryptodome.Hash import SHA256
 from Cryptodome.PublicKey import RSA
-import urllib3
+from Cryptodome.Signature import pkcs1_15
 
 from blobfile import _common as common
 from blobfile._common import (
-    Request,
-    Error,
-    Stat,
     GCP_BASE_URL,
-    Config,
-    TokenManager,
-    RequestFailure,
-    RestartableStreamingWriteFailure,
     BaseStreamingReadFile,
     BaseStreamingWriteFile,
-    FileBody,
+    Config,
     DirEntry,
-    strip_slashes,
+    Error,
+    FileBody,
+    Request,
+    RequestFailure,
+    RestartableStreamingWriteFailure,
+    Stat,
+    TokenManager,
     path_join,
+    strip_slashes,
 )
 
 MAX_EXPIRATION = 7 * 24 * 60 * 60
@@ -810,4 +810,4 @@ def join_paths(conf: Config, a: str, b: str) -> str:
     return combine_path(bucket, obj)
 
 
-access_token_manager = TokenManager(_get_access_token)
+access_token_manager = TokenManager(_get_access_token, "gcp")

--- a/blobfile/_ops.py
+++ b/blobfile/_ops.py
@@ -1,19 +1,20 @@
 # https://mypy.readthedocs.io/en/stable/common_issues.html#using-classes-that-are-generic-in-stubs-but-not-at-runtime
 from __future__ import annotations
 
-import urllib3
 import concurrent.futures
 from typing import (
-    overload,
-    Optional,
-    Tuple,
-    Callable,
-    Sequence,
-    Iterator,
-    TextIO,
-    BinaryIO,
     TYPE_CHECKING,
+    BinaryIO,
+    Callable,
+    Iterator,
+    Optional,
+    Sequence,
+    TextIO,
+    Tuple,
+    overload,
 )
+
+import urllib3
 
 if TYPE_CHECKING:
     # Literal is only in the stdlib in Python 3.8+
@@ -23,22 +24,20 @@ if TYPE_CHECKING:
     # c) type checkers always know what typing_extensions is
     from typing_extensions import Literal
 
-
-from blobfile._common import Stat, DirEntry
+from blobfile._common import DirEntry, Stat
 from blobfile._context import (
-    DEFAULT_CONNECTION_POOL_MAX_SIZE,
-    DEFAULT_MAX_CONNECTION_POOL_COUNT,
     DEFAULT_AZURE_WRITE_CHUNK_SIZE,
-    DEFAULT_GOOGLE_WRITE_CHUNK_SIZE,
-    DEFAULT_RETRY_LOG_THRESHOLD,
-    DEFAULT_RETRY_COMMON_LOG_THRESHOLD,
-    DEFAULT_CONNECT_TIMEOUT,
-    DEFAULT_READ_TIMEOUT,
     DEFAULT_BUFFER_SIZE,
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_CONNECTION_POOL_MAX_SIZE,
+    DEFAULT_GOOGLE_WRITE_CHUNK_SIZE,
+    DEFAULT_MAX_CONNECTION_POOL_COUNT,
+    DEFAULT_READ_TIMEOUT,
+    DEFAULT_RETRY_COMMON_LOG_THRESHOLD,
+    DEFAULT_RETRY_LOG_THRESHOLD,
     create_context,
     default_log_fn,
 )
-
 
 default_context = create_context()
 
@@ -62,6 +61,7 @@ def configure(
     get_http_pool: Optional[Callable[[], urllib3.PoolManager]] = None,
     use_streaming_read: bool = False,
     default_buffer_size: int = DEFAULT_BUFFER_SIZE,
+    save_access_token_to_disk: bool = True,
 ) -> None:
     """
     log_callback: a log callback function `log(msg: string)` to use instead of printing to stdout
@@ -93,6 +93,7 @@ def configure(
         get_http_pool=get_http_pool,
         use_streaming_read=use_streaming_read,
         default_buffer_size=default_buffer_size,
+        save_access_token_to_disk=save_access_token_to_disk,
     )
 
 

--- a/blobfile/_ops.py
+++ b/blobfile/_ops.py
@@ -61,7 +61,7 @@ def configure(
     get_http_pool: Optional[Callable[[], urllib3.PoolManager]] = None,
     use_streaming_read: bool = False,
     default_buffer_size: int = DEFAULT_BUFFER_SIZE,
-    save_access_token_to_disk: bool = True,
+    save_access_token_to_disk: bool = False,
 ) -> None:
     """
     log_callback: a log callback function `log(msg: string)` to use instead of printing to stdout


### PR DESCRIPTION
Adds support to automatically save access tokens to a local file.  Getting an access token currently takes around 250-300ms and can slow for latency-dependent applications.

Open Questions:
* There's a lot of keys that are stored as tuples.  I got around this by saving tuple keys as dicts with a special field but I'm very open to changing this logic.
* I haven't figured out a clean option to change the default behavior if a user doesn't want to save to local disk
* Do we want different files for each type of token? Plus: cleaning security boundaries.  Con: Slightly more logic.  Also, tokens expire after an hour so its a little unclear how much of an issue this is