### PR TITLE
Fix default for use_azure_storage_account_key_fallback in bf.configure

### DIFF
--- a/blobfile/_ops.py
+++ b/blobfile/_ops.py
@@ -57,7 +57,7 @@ def configure(
     connect_timeout: Optional[int] = DEFAULT_CONNECT_TIMEOUT,
     read_timeout: Optional[int] = DEFAULT_READ_TIMEOUT,
     output_az_paths: bool = False,
-    use_azure_storage_account_key_fallback: bool = True,
+    use_azure_storage_account_key_fallback: bool = False,
     get_http_pool: Optional[Callable[[], urllib3.PoolManager]] = None,
     use_streaming_read: bool = False,
     default_buffer_size: int = DEFAULT_BUFFER_SIZE,
@@ -73,7 +73,7 @@ def configure(
     connect_timeout: the maximum amount of time (in seconds) to wait for a connection attempt to a server to succeed, set to None to wait forever
     read_timeout: the maximum amount of time (in seconds) to wait between consecutive read operations for a response from the server, set to None to wait forever
     output_az_paths: output `az://` paths instead of using the `https://` for azure
-    use_azure_storage_account_key_fallback: fallback to storage account keys for azure containers, having this enabled (the default) requires listing your subscriptions and may run into 429 errors if you hit the low azure quotas for subscription listing
+    use_azure_storage_account_key_fallback: fallback to storage account keys for azure containers, having this enabled requires listing your subscriptions and may run into 429 errors if you hit the low azure quotas for subscription listing
     get_http_pool: a function that returns a `urllib3.PoolManager` to be used for requests
     use_streaming_read: if set to `True`, use a single read per file instead of reading a chunk at a time (not recommended for azure)
     default_buffer_size: the default buffer size to use for reading files (and writing local files)


### PR DESCRIPTION
The default was changed in blobfile 1.2.0. The default for `create_context` is correct. Currently this means any call to `configure` re-enables the fallback