### PR TITLE
Loosen requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ setup_dict = dict(
     license="Public Domain",
     packages=find_packages(),
     install_requires=[
-        "pycryptodomex>=3.8",
-        "urllib3>=1.25",
-        "xmltodict>=0.12.0",
-        "filelock>=3.0",
+        "pycryptodomex~=3.8",
+        "urllib3~=1.25",
+        "xmltodict~=0.12",
+        "filelock~=3.0",
     ],
     python_requires=">=3.7.0",
     # indicate that we have type information

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ setup_dict = dict(
     license="Public Domain",
     packages=find_packages(),
     install_requires=[
-        "pycryptodomex~=3.8",
-        "urllib3~=1.25",
-        "xmltodict~=0.12.0",
-        "filelock~=3.0",
+        "pycryptodomex>=3.8",
+        "urllib3>=1.25",
+        "xmltodict>=0.12.0",
+        "filelock>=3.0",
     ],
     python_requires=">=3.7.0",
     # indicate that we have type information


### PR DESCRIPTION
It's nice for libraries to have looser requirements. It's pretty easy to
imagine a world in which we'd want pycryptodomex to be easily
upgradeable.

The impetus for this is xmltodict can actually run kind of hot in some
listing workloads, and 0.13 should be marginally faster than 0.12