### PR TITLE
Support sovereign Azure clouds via ARM metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ The following methods will be tried in order:
 
 If access using credentials fails, anonymous access will be tried.  `blobfile` supports public access for containers marked as public, but not individual blobs.
 
+By default, `blobfile` assumes the public Azure cloud. To target another cloud, set either:
+
+* `AZURE_CLOUD` to a known cloud name such as `AzureUSGovernment`
+* `ARM_CLOUD_METADATA_URL` to the full ARM metadata URL, for example `https://management.usgovcloudapi.net/metadata/endpoints?api-version=2019-05-01`
+
 ## Paths
 
 For Google Cloud Storage and Azure Blobs, directories don't really exist.  These storage systems store the files in a single flat list.  The "/" separators are just part of the filenames and there is no need to call the equivalent of `os.mkdir` on one of these systems.
@@ -134,7 +139,7 @@ GCS paths have the format `gs://<bucket>/<blob>`, you cannot perform any operati
 
 ### Azure Blobs
 
-Azure Blobs URLs have the format `az://<account>/<container>` or `https://<account>.blob.core.windows.net/<container>/<blob>`.  The highest you can go up the hierarchy is `az://<account>/<container>/`, `blobfile` cannot perform any operations on `az://<account>/`.  The `https://` url is the output format by default, but the `az://` urls are accepted as inputs and you can set `output_az_paths=True` to get `az://` urls as output.
+Azure Blobs URLs have the format `az://<account>/<container>` or `https://<account>.blob.<storage suffix>/<container>/<blob>`. The active cloud controls the storage suffix for `https://` Azure URLs, for example `core.windows.net` in public Azure or `core.usgovcloudapi.net` in Azure US Government. The highest you can go up the hierarchy is `az://<account>/<container>/`, `blobfile` cannot perform any operations on `az://<account>/`. The `https://` url is the output format by default, but the `az://` urls are accepted as inputs and you can set `output_az_paths=True` to get `az://` urls as output.
 
 ## Errors
 

--- a/blobfile/_azure.py
+++ b/blobfile/_azure.py
@@ -17,6 +17,7 @@ import urllib3
 
 from blobfile import _common as common
 from blobfile import _xml as xml
+from blobfile._azure_cloud import AzureCloudConfig, get_cloud_config
 from blobfile._common import (
     DEFAULT_RETRY_CODES,
     INVALID_HOSTNAME_STATUS,
@@ -40,6 +41,7 @@ from blobfile._common import (
 SHARED_KEY = "shared_key"
 OAUTH_TOKEN = "oauth_token"
 ANONYMOUS = "anonymous"
+AzureCacheKey = tuple[str, str, str, str]
 
 # it looks like azure signed urls cannot exceed the lifetime of the token used
 # to create them, so don't keep the key around too long
@@ -149,12 +151,30 @@ def load_subscription_ids() -> list[str]:
     return [sub["id"] for sub in subscriptions]
 
 
-def build_url(account: str, template: str, **data: str) -> str:
-    return common.build_url(f"https://{account}.blob.core.windows.net", template, **data)
+def _cloud_config(conf: Config | None = None) -> AzureCloudConfig:
+    if conf is not None:
+        return conf.azure_cloud
+    return get_cloud_config()
+
+
+def _is_https_blob_host_candidate(hostname: str) -> bool:
+    return ".blob." in hostname
+
+
+def azure_cache_key(conf: Config, account: str, container: str) -> AzureCacheKey:
+    cloud = conf.azure_cloud
+    return (cloud.login_endpoint, cloud.storage_endpoint_suffix, account, container)
+
+
+def build_url(account: str, template: str, conf: Config | None = None, **data: str) -> str:
+    return common.build_url(_cloud_config(conf).blob_endpoint_url(account), template, **data)
 
 
 def _create_access_token_request(
-    creds: Mapping[str, str], scope: str, success_codes: Sequence[int] = (200,)
+    creds: Mapping[str, str],
+    scope: str,
+    success_codes: Sequence[int] = (200,),
+    conf: Config | None = None,
 ) -> Request:
     if creds["_azure_auth"] == "refresh":
         # https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#refresh-the-access-token
@@ -180,8 +200,9 @@ def _create_access_token_request(
         tenant_id = creds["tenant_id"]
     else:
         raise AssertionError
+    cloud = _cloud_config(conf)
     return Request(
-        url=f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+        url=f"{cloud.login_endpoint}/{tenant_id}/oauth2/v2.0/token",
         method="POST",
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         data=urllib.parse.urlencode(data).encode("utf8"),
@@ -295,11 +316,13 @@ def generate_signed_url(key: Mapping[str, str], url: str) -> tuple[str, float]:
     return url + "?" + query, t
 
 
-def split_path(path: str) -> tuple[str, str, str]:
+def split_path(
+    path: str, conf: Config | None = None, *, validate: bool = True
+) -> tuple[str, str, str]:
     if path.startswith("az://"):
         return split_az_path(path)
     elif path.startswith("https://"):
-        return split_https_path(path)
+        return split_https_path(path, conf=conf, validate=validate)
     else:
         raise Error(f"Invalid path: '{path}'")
 
@@ -316,21 +339,45 @@ def split_az_path(path: str) -> tuple[str, str, str]:
     return account, container, obj
 
 
-def split_https_path(path: str) -> tuple[str, str, str]:
-    parts = path[len("https://") :].split("/")
-    if len(parts) < 2:
+def _split_https_path_parts(path: str) -> tuple[str, str, str, str]:
+    parsed = urllib.parse.urlparse(path)
+    hostname = parsed.hostname
+    if parsed.scheme != "https" or hostname is None:
         raise Error(f"Invalid path: '{path}'")
-    hostname = parts[0]
-    container = parts[1]
-    if not hostname.endswith(".blob.core.windows.net") or container == "":
+    if not _is_https_blob_host_candidate(hostname):
         raise Error(f"Invalid path: '{path}'")
-    obj = "/".join(parts[2:])
-    account = hostname.split(".")[0]
+
+    account, sep, host_suffix = hostname.partition(".blob.")
+    if sep == "" or not account or not host_suffix:
+        raise Error(f"Invalid path: '{path}'")
+
+    path_parts = parsed.path.split("/")
+    if len(path_parts) < 2:
+        raise Error(f"Invalid path: '{path}'")
+    container = path_parts[1]
+    if container == "":
+        raise Error(f"Invalid path: '{path}'")
+    obj = "/".join(path_parts[2:])
+    return account, host_suffix, container, obj
+
+
+def split_https_path(
+    path: str, conf: Config | None = None, *, validate: bool = True
+) -> tuple[str, str, str]:
+    account, host_suffix, container, obj = _split_https_path_parts(path)
+    if validate and host_suffix != _cloud_config(conf).storage_endpoint_suffix:
+        raise Error(f"Invalid path: '{path}'")
     return account, container, obj
 
 
-def combine_https_path(account: str, container: str, obj: str) -> str:
-    return f"https://{account}.blob.core.windows.net/{container}/{obj}"
+def _combine_https_path_with_host_suffix(
+    account: str, host_suffix: str, container: str, obj: str
+) -> str:
+    return f"https://{account}.blob.{host_suffix}/{container}/{obj}"
+
+
+def combine_https_path(account: str, container: str, obj: str, conf: Config | None = None) -> str:
+    return f"{_cloud_config(conf).blob_endpoint_url(account)}/{container}/{obj}"
 
 
 def combine_az_path(account: str, container: str, obj: str) -> str:
@@ -341,15 +388,15 @@ def combine_path(conf: Config, account: str, container: str, obj: str) -> str:
     if conf.output_az_paths:
         return combine_az_path(account, container, obj)
     else:
-        return combine_https_path(account, container, obj)
+        return combine_https_path(account, container, obj, conf=conf)
 
 
 def mkdirfile(conf: Config, path: str) -> None:
     if not path.endswith("/"):
         path += "/"
-    account, container, blob = split_path(path)
+    account, container, blob = split_path(path, conf=conf)
     req = Request(
-        url=build_url(account, "/{container}/{blob}", container=container, blob=blob),
+        url=build_url(account, "/{container}/{blob}", conf=conf, container=container, blob=blob),
         method="PUT",
         headers={"x-ms-blob-type": "BlockBlob"},
         success_codes=(201, 400),
@@ -487,7 +534,7 @@ def _can_access_container(
     def build_req() -> Request:
         req = Request(
             method="GET",
-            url=build_url(account, "/{container}", container=container),
+            url=build_url(account, "/{container}", conf=conf, container=container),
             params={"restype": "container", "comp": "list", "maxresults": "1"},
             success_codes=success_codes,
         )
@@ -524,7 +571,10 @@ def _get_storage_account_id(
     conf: Config, subscription_id: str, account: str, auth: tuple[str, str]
 ) -> str | None:
     # get a list of storage accounts
-    url = f"https://management.azure.com/subscriptions/{subscription_id}/providers/Microsoft.Storage/storageAccounts"
+    url = (
+        f"{conf.azure_cloud.arm_endpoint}/subscriptions/{subscription_id}"
+        "/providers/Microsoft.Storage/storageAccounts"
+    )
     params = {"api-version": "2019-04-01"}
     while True:
 
@@ -551,7 +601,7 @@ def _get_storage_account_id(
 
 
 def _get_subscription_ids(conf: Config, auth: tuple[str, str]) -> list[str]:
-    url = "https://management.azure.com/subscriptions"
+    url = f"{conf.azure_cloud.arm_endpoint}/subscriptions"
     params = {"api-version": "2020-01-01"}
     result = []
     while True:
@@ -586,7 +636,7 @@ def _get_storage_account_key(
     # get an access token for the management service
     def build_req_access_token() -> Request:
         return _create_access_token_request(
-            creds=creds, scope="https://management.azure.com/.default"
+            creds=creds, scope=f"{conf.azure_cloud.arm_endpoint}/.default", conf=conf
         )
 
     resp = common.execute_request(conf, build_req_access_token)
@@ -620,7 +670,7 @@ def _get_storage_account_key(
     def build_req_list_keys() -> Request:
         req = Request(
             method="POST",
-            url=f"https://management.azure.com{storage_account_id}/listKeys",
+            url=f"{conf.azure_cloud.arm_endpoint}{storage_account_id}/listKeys",
             params={"api-version": "2019-04-01"},
         )
         return create_api_request(req, auth=auth)
@@ -641,8 +691,8 @@ def _get_storage_account_key(
     raise Error(f"Storage account was found, but storage account keys were missing: '{account}'")
 
 
-def _get_access_token(conf: Config, key: Any) -> tuple[Any, float]:
-    account, container = key
+def _get_access_token(conf: Config, key: AzureCacheKey) -> tuple[Any, float]:
+    _, _, account, container = key
     now = time.time()
     creds = _load_credentials()
     azure_auth = creds.get("_azure_auth")
@@ -662,8 +712,9 @@ def _get_access_token(conf: Config, key: Any) -> tuple[Any, float]:
         def build_req() -> Request:
             return _create_access_token_request(
                 creds=creds,
-                scope=f"https://{account}.blob.core.windows.net/.default",
+                scope=conf.azure_cloud.storage_scope(account),
                 success_codes=(200, 400),
+                conf=conf,
             )
 
         resp = common.execute_request(conf, build_req)
@@ -712,7 +763,7 @@ def _get_access_token(conf: Config, key: Any) -> tuple[Any, float]:
         # we have a service principal, get an oauth token
         def build_req() -> Request:
             return _create_access_token_request(
-                creds=creds, scope="https://storage.azure.com/.default"
+                creds=creds, scope=conf.azure_cloud.storage_scope(), conf=conf
             )
 
         resp = common.execute_request(conf, build_req)
@@ -737,14 +788,14 @@ def _get_access_token(conf: Config, key: Any) -> tuple[Any, float]:
     # This enables the use of Managed Identity, Workload Identity, and other auth methods not implemented here
     elif azure_auth == "azure-identity":
         try:
-            from azure.identity import DefaultAzureCredential  # pyright: ignore
+            from azure.identity import DefaultAzureCredential
         except ImportError:
             raise RuntimeError(
                 "When setting AZURE_USE_IDENTITY=1, you must also install the azure-identity package"
             )
 
-        with DefaultAzureCredential() as cred:
-            token = cred.get_token("https://storage.azure.com/.default")
+        with DefaultAzureCredential(authority=conf.azure_cloud.authority_host) as cred:
+            token = cred.get_token(conf.azure_cloud.storage_scope())
         auth = (OAUTH_TOKEN, token.token)
         if _can_access_container(conf, account, container, auth, out_failures=access_failures):
             return (auth, token.expires_on)
@@ -784,14 +835,14 @@ No Azure credentials were found.  If the container is not marked as public, plea
     raise Error(msg)
 
 
-def _get_sas_token(conf: Config, key: Any) -> tuple[Any, float]:
+def _get_sas_token(conf: Config, key: AzureCacheKey) -> tuple[Any, float]:
     auth = access_token_manager.get_token(conf, key=key)
     if auth[0] == ANONYMOUS:
         # for public containers, use None as the token so that this will be cached
         # and we can tell when we don't have a real SAS token for a container
         return (None, time.time() + SAS_TOKEN_EXPIRATION_SECONDS)
 
-    account, container = key
+    _, _, account, container = key
 
     def build_req() -> Request:
         # https://docs.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas
@@ -799,7 +850,7 @@ def _get_sas_token(conf: Config, key: Any) -> tuple[Any, float]:
         start = (now + datetime.timedelta(hours=-1)).strftime("%Y-%m-%dT%H:%M:%SZ")
         expiry = (now + datetime.timedelta(days=6)).strftime("%Y-%m-%dT%H:%M:%SZ")
         req = Request(
-            url=f"https://{account}.blob.core.windows.net/",
+            url=build_url(account, "/", conf=conf),
             method="POST",
             params=dict(restype="service", comp="userdelegationkey"),
             data={"KeyInfo": {"Start": start, "Expiry": expiry}},
@@ -837,7 +888,10 @@ def execute_api_request(conf: Config, req: Request) -> "urllib3.BaseHTTPResponse
 
     def build_req() -> Request:
         return create_api_request(
-            req, auth=access_token_manager.get_token(conf, key=(account, container))
+            req,
+            auth=access_token_manager.get_token(
+                conf, key=azure_cache_key(conf, account, container)
+            ),
         )
 
     return common.execute_request(conf, build_req)
@@ -947,10 +1001,10 @@ def isdir(conf: Config, path: str) -> bool:
     """
     if not path.endswith("/"):
         path += "/"
-    account, container, blob = split_path(path)
+    account, container, blob = split_path(path, conf=conf)
     if blob == "":
         req = Request(
-            url=build_url(account, "/{container}", container=container, blob=blob),
+            url=build_url(account, "/{container}", conf=conf, container=container, blob=blob),
             method="GET",
             params=dict(restype="container"),
             success_codes=(200, 404, INVALID_HOSTNAME_STATUS),
@@ -962,7 +1016,7 @@ def isdir(conf: Config, path: str) -> bool:
         # iterator. as it happens, azure is perfectly willing to return an empty first page.
         it = create_page_iterator(
             conf,
-            url=build_url(account, "/{container}", container=container),
+            url=build_url(account, "/{container}", conf=conf, container=container),
             method="GET",
             params=dict(
                 comp="list", restype="container", prefix=blob, delimiter="/", maxresults="1"
@@ -1021,12 +1075,14 @@ class StreamingReadFile(BaseStreamingReadFile):
     def _request_chunk(
         self, streaming: bool, start: int, end: int | None = None
     ) -> "urllib3.BaseHTTPResponse":
-        account, container, blob = split_path(self._path)
+        account, container, blob = split_path(self._path, conf=self._conf)
         headers = {"Range": common.calc_range(start=start, end=end)}
         if self._version is not None:
             headers["If-Match"] = self._version
         req = Request(
-            url=build_url(account, "/{container}/{blob}", container=container, blob=blob),
+            url=build_url(
+                account, "/{container}/{blob}", conf=self._conf, container=container, blob=blob
+            ),
             method="GET",
             headers=headers,
             success_codes=(206, 416),
@@ -1044,8 +1100,10 @@ class StreamingWriteFile(BaseStreamingWriteFile):
         self, conf: Config, path: str, version: str | None, partial_writes_on_exc: bool
     ) -> None:
         self._path = path
-        account, container, blob = split_path(path)
-        self._url = build_url(account, "/{container}/{blob}", container=container, blob=blob)
+        account, container, blob = split_path(path, conf=conf)
+        self._url = build_url(
+            account, "/{container}/{blob}", conf=conf, container=container, blob=blob
+        )
         self._upload_id = rng.randint(0, 2**47 - 1)
         self._block_index = 0
         self._version: str | None = version  # for azure, this is an etag
@@ -1253,8 +1311,8 @@ def parallel_upload(
     with open(src, "rb") as f:
         md5_digest = common.block_md5(f)
 
-    account, container, blob = split_path(dst)
-    dst_url = build_url(account, "/{container}/{blob}", container=container, blob=blob)
+    account, container, blob = split_path(dst, conf=conf)
+    dst_url = build_url(account, "/{container}/{blob}", conf=conf, container=container, blob=blob)
 
     upload_id = rng.randint(0, 2**47 - 1)
     s = os.stat(src)
@@ -1291,11 +1349,11 @@ def parallel_upload(
 
 
 def maybe_stat(conf: Config, path: str, *, version: str | None = None) -> Stat | None:
-    account, container, blob = split_path(path)
+    account, container, blob = split_path(path, conf=conf)
     if blob == "":
         return None
     req = Request(
-        url=build_url(account, "/{container}/{blob}", container=container, blob=blob),
+        url=build_url(account, "/{container}/{blob}", conf=conf, container=container, blob=blob),
         method="HEAD",
         success_codes=(200, 404, INVALID_HOSTNAME_STATUS),
     )
@@ -1311,11 +1369,11 @@ def maybe_stat(conf: Config, path: str, *, version: str | None = None) -> Stat |
 
 
 def remove(conf: Config, path: str) -> bool:
-    account, container, blob = split_path(path)
+    account, container, blob = split_path(path, conf=conf)
     if blob == "":
         raise FileNotFoundError(f"The system cannot find the path specified: '{path}'")
     req = Request(
-        url=build_url(account, "/{container}/{blob}", container=container, blob=blob),
+        url=build_url(account, "/{container}/{blob}", conf=conf, container=container, blob=blob),
         method="DELETE",
         success_codes=(202, 404, INVALID_HOSTNAME_STATUS),
     )
@@ -1324,9 +1382,9 @@ def remove(conf: Config, path: str) -> bool:
 
 
 def maybe_update_md5(conf: Config, path: str, etag: str, hexdigest: str) -> bool:
-    account, container, blob = split_path(path)
+    account, container, blob = split_path(path, conf=conf)
     req = Request(
-        url=build_url(account, "/{container}/{blob}", container=container, blob=blob),
+        url=build_url(account, "/{container}/{blob}", conf=conf, container=container, blob=blob),
         method="HEAD",
         headers={"If-Match": etag},
         success_codes=(200, 404, 412),
@@ -1346,7 +1404,7 @@ def maybe_update_md5(conf: Config, path: str, etag: str, hexdigest: str) -> bool
     )
 
     req = Request(
-        url=build_url(account, "/{container}/{blob}", container=container, blob=blob),
+        url=build_url(account, "/{container}/{blob}", conf=conf, container=container, blob=blob),
         method="PUT",
         params=dict(comp="properties"),
         headers={
@@ -1369,10 +1427,10 @@ def list_blobs(conf: Config, path: str, delimiter: str | None = None) -> Iterato
     if delimiter is not None:
         params["delimiter"] = delimiter
 
-    account, container, prefix = split_path(path)
+    account, container, prefix = split_path(path, conf=conf)
     it = create_page_iterator(
         conf,
-        url=build_url(account, "/{container}", container=container),
+        url=build_url(account, "/{container}", conf=conf, container=container),
         method="GET",
         params=dict(comp="list", restype="container", prefix=prefix, **params),
     )
@@ -1380,17 +1438,17 @@ def list_blobs(conf: Config, path: str, delimiter: str | None = None) -> Iterato
         yield from _get_entries(conf, account, container, result)
 
 
-def entry_from_dirpath(path: str) -> DirEntry:
+def entry_from_dirpath(path: str, conf: Config | None = None) -> DirEntry:
     if path.endswith("/"):
         path = path[:-1]
-    _, _, obj = split_path(path)
+    _, _, obj = split_path(path, conf=conf)
     name = obj.split("/")[-1]
     return DirEntry(name=name, path=path, is_dir=True, is_file=False, stat=None)
 
 
-def entry_from_path_stat(path: str, stat: Stat) -> DirEntry:
+def entry_from_path_stat(path: str, stat: Stat, conf: Config | None = None) -> DirEntry:
     assert not path.endswith("/")
-    _, _, obj = split_path(path)
+    _, _, obj = split_path(path, conf=conf)
     name = obj.split("/")[-1]
     return DirEntry(name=name, path=path, is_dir=False, is_file=True, stat=stat)
 
@@ -1404,21 +1462,21 @@ def _get_entries(
     if "BlobPrefix" in blobs:
         for bp in blobs["BlobPrefix"]:
             path = combine_path(conf, account, container, bp["Name"])
-            yield entry_from_dirpath(path)
+            yield entry_from_dirpath(path, conf=conf)
     if "Blob" in blobs:
         for b in blobs["Blob"]:
             path = combine_path(conf, account, container, b["Name"])
             if b["Name"].endswith("/"):
-                yield entry_from_dirpath(path)
+                yield entry_from_dirpath(path, conf=conf)
             else:
                 props = b["Properties"]
-                yield entry_from_path_stat(path, make_stat(props))
+                yield entry_from_path_stat(path, make_stat(props), conf=conf)
 
 
 def get_url(conf: Config, path: str) -> tuple[str, float | None]:
-    account, container, blob = split_path(path)
-    url = build_url(account, "/{container}/{blob}", container=container, blob=blob)
-    token = sas_token_manager.get_token(conf=conf, key=(account, container))
+    account, container, blob = split_path(path, conf=conf)
+    url = build_url(account, "/{container}/{blob}", conf=conf, container=container, blob=blob)
+    token = sas_token_manager.get_token(conf=conf, key=azure_cache_key(conf, account, container))
     if token is None:
         # the container has public access
         return url, float("inf")
@@ -1426,12 +1484,12 @@ def get_url(conf: Config, path: str) -> tuple[str, float | None]:
 
 
 def set_mtime(conf: Config, path: str, mtime: float, version: str | None = None) -> bool:
-    account, container, blob = split_path(path)
+    account, container, blob = split_path(path, conf=conf)
     headers = {}
     if version is not None:
         headers["If-Match"] = version
     req = Request(
-        url=build_url(account, "/{container}/{blob}", container=container, blob=blob),
+        url=build_url(account, "/{container}/{blob}", conf=conf, container=container, blob=blob),
         method="HEAD",
         params=dict(comp="metadata"),
         headers=headers,
@@ -1448,7 +1506,7 @@ def set_mtime(conf: Config, path: str, mtime: float, version: str | None = None)
     if version is not None:
         headers["If-Match"] = version
     req = Request(
-        url=build_url(account, "/{container}/{blob}", container=container, blob=blob),
+        url=build_url(account, "/{container}/{blob}", conf=conf, container=container, blob=blob),
         method="PUT",
         params=dict(comp="metadata"),
         headers=headers,
@@ -1460,29 +1518,46 @@ def set_mtime(conf: Config, path: str, mtime: float, version: str | None = None)
     return resp.status == 200
 
 
-def dirname(conf: Config, path: str) -> str:
-    account, container, obj = split_path(path)
+def dirname(conf: Config, path: str, *, validate: bool = True) -> str:
+    host_suffix: str | None = None
+    if path.startswith("https://"):
+        account, host_suffix, container, obj = _split_https_path_parts(path)
+        if validate and host_suffix != conf.azure_cloud.storage_endpoint_suffix:
+            raise Error(f"Invalid path: '{path}'")
+    else:
+        account, container, obj = split_path(path, conf=conf, validate=validate)
+
     obj = strip_slashes(obj)
     if "/" in obj:
         obj = "/".join(obj.split("/")[:-1])
-        return combine_path(conf, account, container, obj)
+        if conf.output_az_paths:
+            return combine_az_path(account, container, obj)
+        if host_suffix is not None:
+            return _combine_https_path_with_host_suffix(account, host_suffix, container, obj)
+        return combine_https_path(account, container, obj, conf=conf)
     else:
-        return combine_path(conf, account, container, "")[:-1]
+        if conf.output_az_paths:
+            return combine_az_path(account, container, "")[:-1]
+        if host_suffix is not None:
+            return _combine_https_path_with_host_suffix(account, host_suffix, container, "")[:-1]
+        return combine_https_path(account, container, "", conf=conf)[:-1]
 
 
 def remote_copy(conf: Config, src: str, dst: str, return_md5: bool) -> str | None:
     # https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob
-    dst_account, dst_container, dst_blob = split_path(dst)
-    src_account, src_container, src_blob = split_path(src)
+    dst_account, dst_container, dst_blob = split_path(dst, conf=conf)
+    src_account, src_container, src_blob = split_path(src, conf=conf)
 
     def build_req() -> Request:
         src_url = build_url(
-            src_account, "/{container}/{blob}", container=src_container, blob=src_blob
+            src_account, "/{container}/{blob}", conf=conf, container=src_container, blob=src_blob
         )
         if src_account != dst_account:
             # the signed url can expire, so technically we should get the sas_token and build the signed url
             # each time we build a new request
-            sas_token = sas_token_manager.get_token(conf=conf, key=(src_account, src_container))
+            sas_token = sas_token_manager.get_token(
+                conf=conf, key=azure_cache_key(conf, src_account, src_container)
+            )
             # if we don't get a token, it's likely we have anonymous access to the container
             # if we do get a token, the container is likely private and we need to use
             # a signed url as the source
@@ -1490,14 +1565,21 @@ def remote_copy(conf: Config, src: str, dst: str, return_md5: bool) -> str | Non
                 src_url, _ = generate_signed_url(key=sas_token, url=src_url)
         req = Request(
             url=build_url(
-                dst_account, "/{container}/{blob}", container=dst_container, blob=dst_blob
+                dst_account,
+                "/{container}/{blob}",
+                conf=conf,
+                container=dst_container,
+                blob=dst_blob,
             ),
             method="PUT",
             headers={"x-ms-copy-source": src_url},
             success_codes=(202, 404, 409, INVALID_HOSTNAME_STATUS),
         )
         return create_api_request(
-            req, auth=access_token_manager.get_token(conf=conf, key=(dst_account, dst_container))
+            req,
+            auth=access_token_manager.get_token(
+                conf=conf, key=azure_cache_key(conf, dst_account, dst_container)
+            ),
         )
 
     copy_id = None
@@ -1543,7 +1625,11 @@ def remote_copy(conf: Config, src: str, dst: str, return_md5: bool) -> str | Non
         time.sleep(next(backoff_generator))
         req = Request(
             url=build_url(
-                dst_account, "/{container}/{blob}", container=dst_container, blob=dst_blob
+                dst_account,
+                "/{container}/{blob}",
+                conf=conf,
+                container=dst_container,
+                blob=dst_blob,
             ),
             method="GET",
         )
@@ -1562,11 +1648,22 @@ def remote_copy(conf: Config, src: str, dst: str, return_md5: bool) -> str | Non
     return None
 
 
-def join_paths(conf: Config, url: str, relpath: str) -> str:
+def join_paths(conf: Config, url: str, relpath: str, *, validate: bool = True) -> str:
     parsed_url = urllib.parse.urlparse(url)
+    host_suffix: str | None = None
     if parsed_url.scheme == "https":
-        account, host = parsed_url.netloc.split(".", maxsplit=1)
-        if host != "blob.core.windows.net":
+        hostname = parsed_url.hostname
+        if hostname is None or not _is_https_blob_host_candidate(hostname):
+            raise Error(f"Invalid URL '{url}'; expected Azure blob host")
+        account, sep, host_suffix = hostname.partition(".blob.")
+        if sep == "" or not account or not host_suffix:
+            raise Error(f"Invalid URL '{url}'; expected Azure blob host")
+        if validate and host_suffix != conf.azure_cloud.storage_endpoint_suffix:
+            host = (
+                parsed_url.netloc.split(".", maxsplit=1)[1]
+                if "." in parsed_url.netloc
+                else parsed_url.netloc
+            )
             raise Error(f"Invalid URL '{url}'; unexpected host '{host}'")
     elif parsed_url.scheme == "az":
         account = parsed_url.netloc
@@ -1591,23 +1688,33 @@ def join_paths(conf: Config, url: str, relpath: str) -> str:
     blob = path_join(blob, relpath)
     if blob.startswith("/"):
         blob = blob[1:]
-    return combine_path(conf, account, container, blob)
+    if conf.output_az_paths:
+        return combine_az_path(account, container, blob)
+    if host_suffix is not None:
+        return _combine_https_path_with_host_suffix(account, host_suffix, container, blob)
+    return combine_https_path(account, container, blob, conf=conf)
 
 
 def _put_block_from_url(
     conf: Config, src: str, start: int, size: int, dst: str, block_id: str
 ) -> None:
-    src_account, src_container, src_blob = split_path(src)
-    dst_account, dst_container, dst_blob = split_path(dst)
+    src_account, src_container, src_blob = split_path(src, conf=conf)
+    dst_account, dst_container, dst_blob = split_path(dst, conf=conf)
 
-    src_url = build_url(src_account, "/{container}/{blob}", container=src_container, blob=src_blob)
+    src_url = build_url(
+        src_account, "/{container}/{blob}", conf=conf, container=src_container, blob=src_blob
+    )
 
-    dst_url = build_url(dst_account, "/{container}/{blob}", container=dst_container, blob=dst_blob)
+    dst_url = build_url(
+        dst_account, "/{container}/{blob}", conf=conf, container=dst_container, blob=dst_blob
+    )
 
     def build_req() -> Request:
         # the signed url can expire, so technically we should get the sas_token and build the signed url
         # each time we build a new request
-        sas_token = sas_token_manager.get_token(conf=conf, key=(src_account, src_container))
+        sas_token = sas_token_manager.get_token(
+            conf=conf, key=azure_cache_key(conf, src_account, src_container)
+        )
         # if we don't get a token, it's likely we have anonymous access to the container
         # if we do get a token, the container is likely private and we need to use
         # a signed url as the source
@@ -1627,7 +1734,10 @@ def _put_block_from_url(
             success_codes=(201, 404, INVALID_HOSTNAME_STATUS),
         )
         return create_api_request(
-            req, auth=access_token_manager.get_token(conf=conf, key=(dst_account, dst_container))
+            req,
+            auth=access_token_manager.get_token(
+                conf=conf, key=azure_cache_key(conf, dst_account, dst_container)
+            ),
         )
 
     resp = common.execute_request(conf, build_req)
@@ -1679,8 +1789,10 @@ def parallel_remote_copy(
     for future in futures:
         future.result()
 
-    dst_account, dst_container, dst_blob = split_path(dst)
-    dst_url = build_url(dst_account, "/{container}/{blob}", container=dst_container, blob=dst_blob)
+    dst_account, dst_container, dst_blob = split_path(dst, conf=conf)
+    dst_url = build_url(
+        dst_account, "/{container}/{blob}", conf=conf, container=dst_container, blob=dst_blob
+    )
 
     _finalize_blob(
         conf=conf,

--- a/blobfile/_azure_cloud.py
+++ b/blobfile/_azure_cloud.py
@@ -1,0 +1,171 @@
+"""Azure cloud configuration with ARM metadata discovery.
+
+Supports multiple Azure clouds (Public, US Government, airgapped) by discovering
+endpoints from the ARM cloud metadata endpoint.
+
+`ARM_CLOUD_METADATA_URL` is treated as the full metadata URL, for example:
+`https://management.usgovcloudapi.net/metadata/endpoints?api-version=2019-05-01`.
+
+Configuration resolution order:
+    1. ARM_CLOUD_METADATA_URL env var set -> fetch metadata, select cloud by AZURE_CLOUD
+       or by matching the metadata URL's ARM endpoint
+    2. AZURE_CLOUD env var set (no metadata URL) -> use built-in preset
+    3. Default -> public cloud preset (no network call)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+STORAGE_AUDIENCE = "https://storage.azure.com"
+
+
+@dataclass(frozen=True)
+class AzureCloudConfig:
+    storage_endpoint_suffix: str
+    login_endpoint: str
+    arm_endpoint: str
+
+    def blob_endpoint_url(self, account: str) -> str:
+        return f"https://{account}.blob.{self.storage_endpoint_suffix}"
+
+    @property
+    def authority_host(self) -> str:
+        parsed = urllib.parse.urlsplit(self.login_endpoint)
+        return (parsed.netloc or parsed.path).rstrip("/")
+
+    def storage_scope(self, account: str | None = None) -> str:
+        if account:
+            return f"https://{account}.blob.{self.storage_endpoint_suffix}/.default"
+        return f"{STORAGE_AUDIENCE}/.default"
+
+
+def _strip_trailing_slash(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _arm_endpoint_from_metadata_url(metadata_url: str) -> str:
+    parsed = urllib.parse.urlsplit(metadata_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"Invalid ARM metadata URL '{metadata_url}'")
+    return _strip_trailing_slash(f"{parsed.scheme}://{parsed.netloc}")
+
+
+AZURE_PUBLIC_CLOUD = AzureCloudConfig(
+    storage_endpoint_suffix="core.windows.net",
+    login_endpoint="https://login.microsoftonline.com",
+    arm_endpoint="https://management.azure.com",
+)
+
+AZURE_US_GOV_CLOUD = AzureCloudConfig(
+    storage_endpoint_suffix="core.usgovcloudapi.net",
+    login_endpoint="https://login.microsoftonline.us",
+    arm_endpoint="https://management.usgovcloudapi.net",
+)
+
+_CLOUD_PRESETS: dict[str, AzureCloudConfig] = {
+    "AzureCloud": AZURE_PUBLIC_CLOUD,
+    "AzureUSGovernment": AZURE_US_GOV_CLOUD,
+}
+
+
+def _fetch_arm_cloud_metadata(metadata_url: str) -> list[dict[str, Any]]:
+    req = urllib.request.Request(metadata_url, headers={"User-Agent": "blobfile"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            metadata = json.loads(resp.read())
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Failed to fetch ARM cloud metadata from '{metadata_url}': {e}") from e
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"ARM cloud metadata from '{metadata_url}' was not valid JSON: {e}"
+        ) from e
+
+    if not isinstance(metadata, list):
+        raise RuntimeError(
+            f"ARM cloud metadata from '{metadata_url}' had unexpected type "
+            f"{type(metadata).__name__}; expected a list of cloud definitions"
+        )
+    return metadata
+
+
+def _cloud_config_from_metadata(cloud_entry: dict[str, Any]) -> AzureCloudConfig:
+    try:
+        storage_endpoint_suffix = cloud_entry["suffixes"]["storage"]
+        login_endpoint = cloud_entry["authentication"]["loginEndpoint"]
+        arm_endpoint = cloud_entry["resourceManager"]
+    except KeyError as e:
+        raise ValueError(f"ARM metadata entry missing required field {e!s}: {cloud_entry!r}") from e
+
+    return AzureCloudConfig(
+        storage_endpoint_suffix=storage_endpoint_suffix,
+        login_endpoint=_strip_trailing_slash(login_endpoint),
+        arm_endpoint=_strip_trailing_slash(arm_endpoint),
+    )
+
+
+def _select_cloud_from_metadata(
+    metadata: list[dict[str, Any]], cloud_name: str | None, arm_endpoint: str | None = None
+) -> dict[str, Any]:
+    if cloud_name:
+        for entry in metadata:
+            if entry.get("name") == cloud_name:
+                return entry
+        available = [entry.get("name", "unknown") for entry in metadata]
+        raise ValueError(
+            f"Cloud '{cloud_name}' not found in ARM metadata. Available clouds: {available}"
+        )
+
+    if not metadata:
+        raise ValueError("ARM metadata response contained no cloud definitions")
+
+    if arm_endpoint:
+        normalized_arm_endpoint = _strip_trailing_slash(arm_endpoint)
+        for entry in metadata:
+            resource_manager = entry.get("resourceManager")
+            if isinstance(resource_manager, str):
+                if _strip_trailing_slash(resource_manager) == normalized_arm_endpoint:
+                    return entry
+
+        available = [
+            _strip_trailing_slash(resource_manager)
+            for entry in metadata
+            if isinstance(resource_manager := entry.get("resourceManager"), str)
+        ]
+        raise ValueError(
+            f"ARM endpoint '{normalized_arm_endpoint}' not found in ARM metadata. "
+            f"Available resourceManager endpoints: {available}"
+        )
+
+    return metadata[0]
+
+
+def resolve_cloud_config(metadata_url: str | None, cloud_name: str | None) -> AzureCloudConfig:
+    if metadata_url:
+        metadata = _fetch_arm_cloud_metadata(metadata_url)
+        arm_endpoint = _arm_endpoint_from_metadata_url(metadata_url)
+        cloud_entry = _select_cloud_from_metadata(metadata, cloud_name, arm_endpoint=arm_endpoint)
+        return _cloud_config_from_metadata(cloud_entry)
+
+    if cloud_name:
+        if cloud_name in _CLOUD_PRESETS:
+            return _CLOUD_PRESETS[cloud_name]
+        raise ValueError(
+            f"Unknown cloud '{cloud_name}'. Known clouds: {list(_CLOUD_PRESETS.keys())}. "
+            f"Set ARM_CLOUD_METADATA_URL to discover endpoints for custom clouds."
+        )
+
+    return AZURE_PUBLIC_CLOUD
+
+
+def get_cloud_config() -> AzureCloudConfig:
+    return resolve_cloud_config(
+        metadata_url=os.environ.get("ARM_CLOUD_METADATA_URL"),
+        cloud_name=os.environ.get("AZURE_CLOUD"),
+    )

--- a/blobfile/_azure_cloud_test.py
+++ b/blobfile/_azure_cloud_test.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import os
+import pickle
+import sys
+import urllib.error
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from blobfile import _azure as azure
+from blobfile import _common as common
+from blobfile import _context as context
+from blobfile import _ops as ops
+from blobfile._azure_cloud import (
+    AZURE_PUBLIC_CLOUD,
+    AZURE_US_GOV_CLOUD,
+    _arm_endpoint_from_metadata_url,
+    _cloud_config_from_metadata,
+    _fetch_arm_cloud_metadata,
+    _select_cloud_from_metadata,
+    get_cloud_config,
+)
+
+SAMPLE_ARM_METADATA = [
+    {
+        "name": "AzureCloud",
+        "authentication": {
+            "loginEndpoint": "https://login.microsoftonline.com/",
+            "audiences": ["https://management.core.windows.net/", "https://management.azure.com/"],
+        },
+        "resourceManager": "https://management.azure.com/",
+        "suffixes": {"storage": "core.windows.net", "keyVaultDns": "vault.azure.net"},
+    },
+    {
+        "name": "AzureUSGovernment",
+        "authentication": {
+            "loginEndpoint": "https://login.microsoftonline.us",
+            "audiences": ["https://management.core.usgovcloudapi.net"],
+        },
+        "resourceManager": "https://management.usgovcloudapi.net",
+        "suffixes": {"storage": "core.usgovcloudapi.net", "keyVaultDns": "vault.usgovcloudapi.net"},
+    },
+]
+
+
+class TestAzureCloudHelpers:
+    def test_arm_endpoint_from_metadata_url(self):
+        assert (
+            _arm_endpoint_from_metadata_url(
+                "https://management.azure.com/metadata/endpoints?api-version=2019-05-01"
+            )
+            == "https://management.azure.com"
+        )
+        assert (
+            _arm_endpoint_from_metadata_url(
+                "https://management.usgovcloudapi.net/metadata/endpoints?api-version=2019-05-01"
+            )
+            == "https://management.usgovcloudapi.net"
+        )
+
+    def test_fetch_arm_cloud_metadata_uses_supplied_url(self):
+        response = MagicMock()
+        response.read.return_value = b'[{"name":"AzureCloud","authentication":{"loginEndpoint":"https://login.microsoftonline.com/"},"resourceManager":"https://management.azure.com/","suffixes":{"storage":"core.windows.net"}}]'
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+
+        with patch("urllib.request.urlopen", return_value=response) as mock_urlopen:
+            metadata = _fetch_arm_cloud_metadata(
+                "https://management.azure.com/metadata/endpoints?api-version=2019-05-01"
+            )
+
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == (
+            "https://management.azure.com/metadata/endpoints?api-version=2019-05-01"
+        )
+        assert metadata[0]["name"] == "AzureCloud"
+
+    def test_fetch_arm_cloud_metadata_network_error(self):
+        with patch(
+            "urllib.request.urlopen", side_effect=urllib.error.URLError("connection refused")
+        ):
+            with pytest.raises(RuntimeError, match="Failed to fetch ARM cloud metadata"):
+                _fetch_arm_cloud_metadata("https://management.invalid")
+
+    def test_fetch_arm_cloud_metadata_invalid_json(self):
+        response = MagicMock()
+        response.read.return_value = b"{"
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+
+        with patch("urllib.request.urlopen", return_value=response):
+            with pytest.raises(RuntimeError, match="was not valid JSON"):
+                _fetch_arm_cloud_metadata("https://management.azure.com")
+
+    def test_authority_host(self):
+        assert AZURE_PUBLIC_CLOUD.authority_host == "login.microsoftonline.com"
+        assert AZURE_US_GOV_CLOUD.authority_host == "login.microsoftonline.us"
+
+
+class TestCloudConfigFromMetadata:
+    def test_parses_public_cloud(self):
+        assert _cloud_config_from_metadata(SAMPLE_ARM_METADATA[0]) == AZURE_PUBLIC_CLOUD
+
+    def test_parses_us_gov_cloud(self):
+        assert _cloud_config_from_metadata(SAMPLE_ARM_METADATA[1]) == AZURE_US_GOV_CLOUD
+
+    def test_missing_required_field_raises_clear_error(self):
+        bad_entry = {
+            "name": "AzureCloud",
+            "authentication": {},
+            "resourceManager": "https://management.azure.com/",
+            "suffixes": {"storage": "core.windows.net"},
+        }
+        with pytest.raises(ValueError, match="missing required field"):
+            _cloud_config_from_metadata(bad_entry)
+
+
+class TestSelectCloudFromMetadata:
+    def test_select_by_name(self):
+        entry = _select_cloud_from_metadata(SAMPLE_ARM_METADATA, "AzureUSGovernment")
+        assert entry["name"] == "AzureUSGovernment"
+
+    def test_select_first_when_no_name(self):
+        entry = _select_cloud_from_metadata(SAMPLE_ARM_METADATA, None)
+        assert entry["name"] == "AzureCloud"
+
+    def test_select_by_resource_manager_when_no_name(self):
+        entry = _select_cloud_from_metadata(
+            SAMPLE_ARM_METADATA, None, "https://management.usgovcloudapi.net/"
+        )
+        assert entry["name"] == "AzureUSGovernment"
+
+    def test_raises_on_unknown_name(self):
+        with pytest.raises(ValueError, match="not found in ARM metadata"):
+            _select_cloud_from_metadata(SAMPLE_ARM_METADATA, "AzureNonExistent")
+
+    def test_raises_on_empty_metadata(self):
+        with pytest.raises(ValueError, match="no cloud definitions"):
+            _select_cloud_from_metadata([], None)
+
+
+class TestGetCloudConfig:
+    def test_default_is_public_cloud(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert get_cloud_config() == AZURE_PUBLIC_CLOUD
+
+    def test_azure_cloud_selects_preset(self):
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureUSGovernment"}, clear=True):
+            assert get_cloud_config() == AZURE_US_GOV_CLOUD
+
+    def test_azure_cloud_unknown_raises(self):
+        with patch.dict(os.environ, {"AZURE_CLOUD": "UnknownCloud"}, clear=True):
+            with pytest.raises(ValueError, match="Unknown cloud"):
+                get_cloud_config()
+
+    def test_arm_metadata_url_fetches_and_selects(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ARM_CLOUD_METADATA_URL": "https://management.example.com/metadata/endpoints?api-version=2019-05-01",
+                "AZURE_CLOUD": "AzureUSGovernment",
+            },
+            clear=True,
+        ):
+            with patch(
+                "blobfile._azure_cloud._fetch_arm_cloud_metadata", return_value=SAMPLE_ARM_METADATA
+            ) as mock_fetch:
+                cloud = get_cloud_config()
+
+        mock_fetch.assert_called_once_with(
+            "https://management.example.com/metadata/endpoints?api-version=2019-05-01"
+        )
+        assert cloud == AZURE_US_GOV_CLOUD
+
+    def test_arm_metadata_url_matches_resource_manager_when_name_unset(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ARM_CLOUD_METADATA_URL": "https://management.usgovcloudapi.net/metadata/endpoints?api-version=2019-05-01"
+            },
+            clear=True,
+        ):
+            with patch(
+                "blobfile._azure_cloud._fetch_arm_cloud_metadata", return_value=SAMPLE_ARM_METADATA
+            ):
+                cloud = get_cloud_config()
+
+        assert cloud == AZURE_US_GOV_CLOUD
+
+
+class TestLazyConfigResolution:
+    def test_context_does_not_resolve_cloud_at_creation(self):
+        with patch(
+            "blobfile._common.resolve_cloud_config", return_value=AZURE_PUBLIC_CLOUD
+        ) as mock_get:
+            ctx = context.create_context()
+            assert mock_get.call_count == 0
+            assert ctx._conf.azure_cloud == AZURE_PUBLIC_CLOUD
+            assert mock_get.call_count == 1
+            assert ctx._conf.azure_cloud == AZURE_PUBLIC_CLOUD
+            assert mock_get.call_count == 1
+
+    def test_context_pins_cloud_env_before_first_use(self):
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureUSGovernment"}, clear=True):
+            ctx = context.create_context(output_az_paths=False)
+
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureCloud"}, clear=True):
+            assert azure.join_paths(ctx._conf, "az://account/container/dir/", "blob") == (
+                "https://account.blob.core.usgovcloudapi.net/container/dir/blob"
+            )
+
+    def test_pickled_config_uses_snapshotted_cloud(self):
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureUSGovernment"}, clear=True):
+            ctx = context.create_context(output_az_paths=False)
+
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureCloud"}, clear=True):
+            conf = pickle.loads(pickle.dumps(ctx._conf))
+            assert azure.combine_path(conf, "account", "container", "blob") == (
+                "https://account.blob.core.usgovcloudapi.net/container/blob"
+            )
+
+    def test_configure_keeps_default_context_bound_to_live_env(self):
+        with patch.dict(os.environ, {}, clear=True):
+            try:
+                ops.configure(output_az_paths=False)
+                os.environ["AZURE_CLOUD"] = "AzureUSGovernment"
+                assert ops.join("az://account/container/dir/", "blob") == (
+                    "https://account.blob.core.usgovcloudapi.net/container/dir/blob"
+                )
+            finally:
+                ops.configure()
+
+    def test_https_path_helpers_do_not_fetch_metadata(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ARM_CLOUD_METADATA_URL": "https://management.usgovcloudapi.net/metadata/endpoints?api-version=2019-05-01"
+            },
+            clear=True,
+        ):
+            ctx = context.create_context(output_az_paths=False)
+            with patch(
+                "blobfile._azure_cloud._fetch_arm_cloud_metadata", return_value=SAMPLE_ARM_METADATA
+            ) as mock_fetch:
+                path = "https://account.blob.core.usgovcloudapi.net/container/blob"
+                dir_path = "https://account.blob.core.usgovcloudapi.net/container/dir/"
+
+                assert ctx.basename(path) == "blob"
+                assert ctx.dirname(path) == "https://account.blob.core.usgovcloudapi.net/container"
+                assert (
+                    ctx.join(dir_path, "blob")
+                    == "https://account.blob.core.usgovcloudapi.net/container/dir/blob"
+                )
+                assert context._guess_isdir(dir_path, ctx._conf)
+                assert mock_fetch.call_count == 0
+
+
+class TestAzurePathHandling:
+    def test_non_azure_paths_do_not_resolve_cloud(self):
+        with patch(
+            "blobfile._common.get_cloud_config", side_effect=AssertionError("should not resolve")
+        ):
+            assert not context._is_azure_path("C:\\temp\\file.txt")
+            assert not context._is_azure_path("gs://bucket/blob")
+            assert context._is_azure_path("az://account/container")
+            assert not context._is_azure_path("https://example.com/blob")
+
+    def test_azure_path_uses_active_cloud(self):
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureUSGovernment"}, clear=True):
+            ctx = context.create_context(output_az_paths=False)
+            path = azure.combine_path(ctx._conf, "account", "container", "blob")
+
+            assert path == "https://account.blob.core.usgovcloudapi.net/container/blob"
+            assert context._is_azure_path(path, ctx._conf)
+            assert azure.split_path(path, conf=ctx._conf) == ("account", "container", "blob")
+            assert azure.join_paths(ctx._conf, "az://account/container/dir/", "blob") == (
+                "https://account.blob.core.usgovcloudapi.net/container/dir/blob"
+            )
+
+    def test_public_cloud_url_rejected_under_gov_cloud(self):
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureUSGovernment"}, clear=True):
+            ctx = context.create_context(output_az_paths=False)
+            public_url = "https://account.blob.core.windows.net/container/blob"
+
+            assert not context._is_azure_path(public_url, ctx._conf)
+            with pytest.raises(common.Error, match="Invalid path"):
+                azure.split_path(public_url, conf=ctx._conf)
+
+    def test_malformed_https_path_with_empty_container_is_rejected(self):
+        with patch.dict(os.environ, {}, clear=True):
+            ctx = context.create_context(output_az_paths=False)
+            with pytest.raises(common.Error, match="Invalid path"):
+                azure.split_path("https://account.blob.core.windows.net//blob", conf=ctx._conf)
+
+    def test_cache_keys_include_cloud_identity(self):
+        with patch.dict(os.environ, {}, clear=True):
+            public_ctx = context.create_context()
+            public_key = azure.azure_cache_key(public_ctx._conf, "account", "container")
+
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureUSGovernment"}, clear=True):
+            gov_ctx = context.create_context()
+            gov_key = azure.azure_cache_key(gov_ctx._conf, "account", "container")
+
+        assert public_key != gov_key
+
+
+class TestAzureIdentityAuthority:
+    def test_get_access_token_uses_authority_host(self, monkeypatch):
+        calls: dict[str, str] = {}
+
+        class FakeDefaultAzureCredential:
+            def __init__(self, *, authority: str):
+                calls["authority"] = authority
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def get_token(self, scope: str):
+                calls["scope"] = scope
+                return SimpleNamespace(token="token", expires_on=123)
+
+        azure_module = ModuleType("azure")
+        identity_module = ModuleType("azure.identity")
+        identity_module.DefaultAzureCredential = FakeDefaultAzureCredential
+        azure_module.identity = identity_module
+
+        monkeypatch.setitem(sys.modules, "azure", azure_module)
+        monkeypatch.setitem(sys.modules, "azure.identity", identity_module)
+        monkeypatch.setattr(azure, "_can_access_container", lambda *args, **kwargs: True)
+
+        with patch.dict(
+            os.environ, {"AZURE_USE_IDENTITY": "1", "AZURE_CLOUD": "AzureUSGovernment"}, clear=True
+        ):
+            ctx = context.create_context()
+            auth, expires_on = azure._get_access_token(
+                ctx._conf, azure.azure_cache_key(ctx._conf, "account", "container")
+            )
+
+        assert calls["authority"] == "login.microsoftonline.us"
+        assert calls["scope"] == "https://storage.azure.com/.default"
+        assert auth == (azure.OAUTH_TOKEN, "token")
+        assert expires_on == 123
+
+
+class TestDeletePathsUseContextCloud:
+    def test_rmdir_uses_context_cloud_for_delete_url(self, monkeypatch):
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureUSGovernment"}, clear=True):
+            ctx = context.create_context(output_az_paths=False)
+            assert ctx._conf.azure_cloud == AZURE_US_GOV_CLOUD
+
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureCloud"}, clear=True):
+            monkeypatch.setattr(ctx, "listdir", lambda path: iter(()))
+            seen_urls: list[str] = []
+
+            def fake_execute_api_request(conf, req):
+                seen_urls.append(req.url)
+                return SimpleNamespace(status=202, headers={}, data=b"")
+
+            monkeypatch.setattr(context.azure, "execute_api_request", fake_execute_api_request)
+            ctx.rmdir("https://account.blob.core.usgovcloudapi.net/container/dir/")
+
+        assert seen_urls == ["https://account.blob.core.usgovcloudapi.net/container/dir%2F"]
+
+    def test_rmtree_uses_context_cloud_for_delete_urls(self, monkeypatch):
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureUSGovernment"}, clear=True):
+            ctx = context.create_context(output_az_paths=False)
+            assert ctx._conf.azure_cloud == AZURE_US_GOV_CLOUD
+
+        entry = common.DirEntry(
+            path="https://account.blob.core.usgovcloudapi.net/container/dir/blob",
+            name="blob",
+            is_dir=False,
+            is_file=True,
+            stat=None,
+        )
+
+        with patch.dict(os.environ, {"AZURE_CLOUD": "AzureCloud"}, clear=True):
+            monkeypatch.setattr(ctx, "isdir", lambda path: True)
+            monkeypatch.setattr(context.azure, "list_blobs", lambda conf, path: iter([entry]))
+            seen_urls: list[str] = []
+
+            def fake_execute_api_request(conf, req):
+                seen_urls.append(req.url)
+                return SimpleNamespace(status=202, headers={}, data=b"")
+
+            monkeypatch.setattr(context.azure, "execute_api_request", fake_execute_api_request)
+            ctx.rmtree("https://account.blob.core.usgovcloudapi.net/container/dir/")
+
+        assert seen_urls == ["https://account.blob.core.usgovcloudapi.net/container/dir%2Fblob"]

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -25,6 +25,7 @@ import filelock
 import urllib3
 from urllib3.util.retry import Retry
 
+from blobfile._azure_cloud import AzureCloudConfig, get_cloud_config, resolve_cloud_config
 from blobfile import _xml as xml
 
 CHUNK_SIZE = 8 * 2**20
@@ -330,6 +331,9 @@ class Config:
         get_deadline: Callable[[], float | None] | None,
         save_access_token_to_disk: bool,
         multiprocessing_start_method: str,
+        azure_cloud_name: str | None,
+        arm_cloud_metadata_url: str | None,
+        use_env_for_azure_cloud: bool,
     ) -> None:
         self.log_callback = log_callback
         self.connection_pool_max_size = connection_pool_max_size
@@ -349,6 +353,10 @@ class Config:
         self.get_deadline = get_deadline
         self.save_access_token_to_disk = save_access_token_to_disk
         self.multiprocessing_start_method = multiprocessing_start_method
+        self._azure_cloud_name = azure_cloud_name
+        self._arm_cloud_metadata_url = arm_cloud_metadata_url
+        self._use_env_for_azure_cloud = use_env_for_azure_cloud
+        self._azure_cloud_cache: AzureCloudConfig | None = None
 
         if get_http_pool is None:
             if (
@@ -365,6 +373,18 @@ class Config:
             return global_pool_director.get_http_pool()
         else:
             return self._get_http_pool()
+
+    @property
+    def azure_cloud(self) -> AzureCloudConfig:
+        if self._azure_cloud_cache is None:
+            if self._use_env_for_azure_cloud:
+                self._azure_cloud_cache = get_cloud_config()
+            else:
+                self._azure_cloud_cache = resolve_cloud_config(
+                    metadata_url=self._arm_cloud_metadata_url,
+                    cloud_name=self._azure_cloud_name,
+                )
+        return self._azure_cloud_cache
 
 
 class WindowedFile:
@@ -615,23 +635,25 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
                 # an invalid hostname from a network error
                 url = urllib.parse.urlparse(req.url)
                 assert url.hostname is not None
-                if (
-                    url.hostname.endswith(".blob.core.windows.net")
-                    and _check_hostname(url.hostname) == HOSTNAME_DOES_NOT_EXIST
-                ):
-                    # in order to handle the azure failures in some sort-of-reasonable way
-                    # create a fake response that has a special status code we can
-                    # handle just like a 404
-                    fake_resp = urllib3.response.HTTPResponse(
-                        status=INVALID_HOSTNAME_STATUS,
-                        body=io.BytesIO(b""),  # avoid error when using "with resp:"
-                    )
-                    if fake_resp.status in req.success_codes:
-                        return fake_resp
-                    else:
-                        raise RequestFailure.create_from_request_response(
-                            "host does not exist", request=req, response=fake_resp
-                        ) from e
+                if ".blob." in url.hostname:
+                    azure_blob_suffix = f".blob.{conf.azure_cloud.storage_endpoint_suffix}"
+                    if (
+                        url.hostname.endswith(azure_blob_suffix)
+                        and _check_hostname(url.hostname) == HOSTNAME_DOES_NOT_EXIST
+                    ):
+                        # in order to handle the azure failures in some sort-of-reasonable way
+                        # create a fake response that has a special status code we can
+                        # handle just like a 404
+                        fake_resp = urllib3.response.HTTPResponse(
+                            status=INVALID_HOSTNAME_STATUS,
+                            body=io.BytesIO(b""),  # avoid error when using "with resp:"
+                        )
+                        if fake_resp.status in req.success_codes:
+                            return fake_resp
+                        else:
+                            raise RequestFailure.create_from_request_response(
+                                "host does not exist", request=req, response=fake_resp
+                            ) from e
 
             err = RequestFailure.create_from_request_response(
                 message=f"request failed with exception {e}",

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -89,9 +89,9 @@ class Context:
         dst = path_to_str(dst)
         # it would be best to check isdir() for remote paths, but that would
         # involve 2 extra network requests, so just do this test instead
-        if _guess_isdir(src):
+        if _guess_isdir(src, self._conf):
             raise IsADirectoryError(f"Is a directory: '{src}'")
-        if _guess_isdir(dst):
+        if _guess_isdir(dst, self._conf):
             raise IsADirectoryError(f"Is a directory: '{dst}'")
 
         if not overwrite:
@@ -102,23 +102,23 @@ class Context:
 
         if dst_version is not None:
             assert _is_azure_path(
-                dst
+                dst, self._conf
             ), f"Destination version was specified, but destination path {dst} does not support a version check"
 
         if parallel:
             copy_fn = None
-            if (_is_azure_path(src) or _is_gcp_path(src)) and _is_local_path(dst):
+            if (_is_azure_path(src, self._conf) or _is_gcp_path(src)) and _is_local_path(dst):
                 copy_fn = _parallel_download
 
-            if _is_local_path(src) and _is_azure_path(dst):
+            if _is_local_path(src) and _is_azure_path(dst, self._conf):
                 copy_fn = partial(azure.parallel_upload, dst_version=dst_version)
 
             if _is_local_path(src) and _is_gcp_path(dst):
                 copy_fn = gcp.parallel_upload
 
-            if _is_azure_path(src) and _is_azure_path(dst):
-                src_account, _, _ = azure.split_path(src)
-                dst_account, _, _ = azure.split_path(dst)
+            if _is_azure_path(src, self._conf) and _is_azure_path(dst, self._conf):
+                src_account, _, _ = azure.split_path(src, conf=self._conf)
+                dst_account, _, _ = azure.split_path(dst, conf=self._conf)
                 if src_account != dst_account:
                     # normal remote copy is pretty fast and doesn't benefit from parallelization when used within
                     # a storage account
@@ -137,7 +137,7 @@ class Context:
         if _is_gcp_path(src) and _is_gcp_path(dst):
             return gcp.remote_copy(self._conf, src=src, dst=dst, return_md5=return_md5)
 
-        if _is_azure_path(src) and _is_azure_path(dst):
+        if _is_azure_path(src, self._conf) and _is_azure_path(dst, self._conf):
             # support could be added here for this but it's currently missing
             assert (
                 dst_version is None
@@ -188,7 +188,7 @@ class Context:
             if st is not None:
                 return True
             return self.isdir(path)
-        elif _is_azure_path(path):
+        elif _is_azure_path(path, self._conf):
             st = azure.maybe_stat(self._conf, path)
             if st is not None:
                 return True
@@ -201,8 +201,8 @@ class Context:
         if _is_gcp_path(path):
             _, obj = gcp.split_path(path)
             return obj.split("/")[-1]
-        elif _is_azure_path(path):
-            _, _, obj = azure.split_path(path)
+        elif _is_azure_path(path, self._conf, validate_https_host=False):
+            _, _, obj = azure.split_path(path, conf=self._conf, validate=False)
             return obj.split("/")[-1]
         else:
             return os.path.basename(path)
@@ -250,7 +250,7 @@ class Context:
                         )
                     ),
                 )
-        elif _is_gcp_path(pattern) or _is_azure_path(pattern):
+        elif _is_gcp_path(pattern) or _is_azure_path(pattern, self._conf):
             if "*" not in pattern:
                 entry = _get_entry(self._conf, pattern)
                 if entry is not None:
@@ -263,7 +263,7 @@ class Context:
                     raise Error("Wildcards cannot be used in bucket name")
                 root = gcp.combine_path(bucket, "")
             else:
-                account, container, blob_prefix = azure.split_path(pattern)
+                account, container, blob_prefix = azure.split_path(pattern, conf=self._conf)
                 if "*" in account or "*" in container:
                     raise Error("Wildcards cannot be used in account or container")
                 root = azure.combine_path(self._conf, account, container, "")
@@ -340,7 +340,7 @@ class Context:
             return os.path.isdir(path)
         elif _is_gcp_path(path):
             return gcp.isdir(self._conf, path)
-        elif _is_azure_path(path):
+        elif _is_azure_path(path, self._conf):
             return azure.isdir(self._conf, path)
         else:
             raise Error(f"Unrecognized path: '{path}'")
@@ -352,7 +352,7 @@ class Context:
 
     def scandir(self, path: RemoteOrLocalPath, shard_prefix_length: int = 0) -> Iterator[DirEntry]:
         path = path_to_str(path)
-        if (_is_gcp_path(path) or _is_azure_path(path)) and not path.endswith("/"):
+        if (_is_gcp_path(path) or _is_azure_path(path, self._conf)) and not path.endswith("/"):
             path += "/"
         if not self.exists(path):
             raise FileNotFoundError(f"The system cannot find the path specified: '{path}'")
@@ -383,7 +383,7 @@ class Context:
                             version=None,
                         ),
                     )
-        elif _is_gcp_path(path) or _is_azure_path(path):
+        elif _is_gcp_path(path) or _is_azure_path(path, self._conf):
             if shard_prefix_length == 0:
                 yield from _list_blobs_in_dir(conf=self._conf, prefix=path, exclude_prefix=True)
             else:
@@ -427,7 +427,7 @@ class Context:
             os.makedirs(path, exist_ok=True)
         elif _is_gcp_path(path):
             gcp.mkdirfile(self._conf, path)
-        elif _is_azure_path(path):
+        elif _is_azure_path(path, self._conf):
             azure.mkdirfile(self._conf, path)
         else:
             raise Error(f"Unrecognized path: '{path}'")
@@ -442,7 +442,7 @@ class Context:
             ok = gcp.remove(self._conf, path)
             if not ok:
                 raise FileNotFoundError(f"The system cannot find the path specified: '{path}'")
-        elif _is_azure_path(path):
+        elif _is_azure_path(path, self._conf):
             if path.endswith("/"):
                 raise IsADirectoryError(f"Is a directory: '{path}'")
             ok = azure.remove(self._conf, path)
@@ -470,8 +470,8 @@ class Context:
 
         if _is_gcp_path(path):
             _, blob = gcp.split_path(path)
-        elif _is_azure_path(path):
-            _, _, blob = azure.split_path(path)
+        elif _is_azure_path(path, self._conf):
+            _, _, blob = azure.split_path(path, conf=self._conf)
         else:
             raise Error(f"Unrecognized path: '{path}'")
 
@@ -498,10 +498,12 @@ class Context:
                 success_codes=(204,),
             )
             gcp.execute_api_request(self._conf, req)
-        elif _is_azure_path(path):
-            account, container, blob = azure.split_path(path)
+        elif _is_azure_path(path, self._conf):
+            account, container, blob = azure.split_path(path, conf=self._conf)
             req = Request(
-                url=azure.build_url(account, "/{container}/{blob}", container=container, blob=blob),
+                url=azure.build_url(
+                    account, "/{container}/{blob}", conf=self._conf, container=container, blob=blob
+                ),
                 method="DELETE",
                 success_codes=(202,),
             )
@@ -519,7 +521,7 @@ class Context:
             if st is None:
                 raise FileNotFoundError(f"No such file: '{path}'")
             return st
-        elif _is_azure_path(path):
+        elif _is_azure_path(path, self._conf):
             st = azure.maybe_stat(self._conf, path)
             if st is None:
                 raise FileNotFoundError(f"No such file: '{path}'")
@@ -535,7 +537,7 @@ class Context:
             return True
         elif _is_gcp_path(path):
             return gcp.set_mtime(self._conf, path=path, mtime=mtime, version=version)
-        elif _is_azure_path(path):
+        elif _is_azure_path(path, self._conf):
             return azure.set_mtime(self._conf, path=path, mtime=mtime, version=version)
         else:
             raise Error(f"Unrecognized path: '{path}'")
@@ -552,7 +554,7 @@ class Context:
 
         if _is_local_path(path):
             shutil.rmtree(path)
-        elif _is_gcp_path(path) or _is_azure_path(path):
+        elif _is_gcp_path(path) or _is_azure_path(path, self._conf):
             if not path.endswith("/"):
                 path += "/"
 
@@ -579,14 +581,14 @@ class Context:
 
                 fn = gcp.execute_api_request
 
-            elif _is_azure_path(path):
+            elif _is_azure_path(path, self._conf):
 
                 def request_generator():
-                    account, container, blob = azure.split_path(path)
+                    account, container, blob = azure.split_path(path, conf=self._conf)
                     for entry in azure.list_blobs(self._conf, path):
                         entry_slash_path = _get_slash_path(entry)
                         entry_account, entry_container, entry_blob = azure.split_path(
-                            entry_slash_path
+                            entry_slash_path, conf=self._conf
                         )
                         assert (
                             entry_account == account
@@ -595,7 +597,11 @@ class Context:
                         )
                         req = Request(
                             url=azure.build_url(
-                                account, "/{container}/{blob}", container=container, blob=entry_blob
+                                account,
+                                "/{container}/{blob}",
+                                conf=self._conf,
+                                container=container,
+                                blob=entry_blob,
                             ),
                             method="DELETE",
                             # 404 is allowed in case a failed request successfully deleted the file
@@ -648,7 +654,7 @@ class Context:
                 if root.endswith(os.sep):
                     root = root[:-1]
                 yield (root, sorted(dirnames), sorted(filenames))
-        elif _is_gcp_path(top) or _is_azure_path(top):
+        elif _is_gcp_path(top) or _is_azure_path(top, self._conf):
             top = _normalize_path(self._conf, top)
             if not top.endswith("/"):
                 top += "/"
@@ -660,7 +666,7 @@ class Context:
                     assert cur.endswith("/")
                     if _is_gcp_path(top):
                         it = gcp.list_blobs(self._conf, cur, delimiter="/")
-                    elif _is_azure_path(top):
+                    elif _is_azure_path(top, self._conf):
                         it = azure.list_blobs(self._conf, cur, delimiter="/")
                     else:
                         raise Error(f"Unrecognized path: '{top}'")
@@ -679,7 +685,7 @@ class Context:
             else:
                 if _is_gcp_path(top):
                     it = gcp.list_blobs(self._conf, top)
-                elif _is_azure_path(top):
+                elif _is_azure_path(top, self._conf):
                     it = azure.list_blobs(self._conf, top)
                 else:
                     raise Error(f"Unrecognized path: '{top}'")
@@ -721,8 +727,8 @@ class Context:
         path = path_to_str(path)
         if _is_gcp_path(path):
             return gcp.dirname(self._conf, path)
-        elif _is_azure_path(path):
-            return azure.dirname(self._conf, path)
+        elif _is_azure_path(path, self._conf, validate_https_host=False):
+            return azure.dirname(self._conf, path, validate=False)
         else:
             return os.path.dirname(path)
 
@@ -737,7 +743,7 @@ class Context:
         path = path_to_str(path)
         if _is_gcp_path(path):
             return gcp.get_url(self._conf, path)
-        elif _is_azure_path(path):
+        elif _is_azure_path(path, self._conf):
             return azure.get_url(self._conf, path)
         elif _is_local_path(path):
             return f"file://{path}", None
@@ -762,7 +768,7 @@ class Context:
             assert st.version is not None
             gcp.maybe_update_md5(self._conf, path, st.version, result)
             return result
-        elif _is_azure_path(path):
+        elif _is_azure_path(path, self._conf):
             st = azure.maybe_stat(self._conf, path)
             if st is None:
                 raise FileNotFoundError(f"No such file: '{path}'")
@@ -868,7 +874,7 @@ class Context:
             A file-like object
         """
         path = path_to_str(path)
-        if _guess_isdir(path):
+        if _guess_isdir(path, self._conf):
             raise IsADirectoryError(f"Is a directory: '{path}'")
 
         if streaming is None:
@@ -921,7 +927,7 @@ class Context:
                     f = io.BufferedReader(f, buffer_size=buffer_size)
                 else:
                     raise Error(f"Unsupported mode: '{mode}'")
-            elif _is_azure_path(path):
+            elif _is_azure_path(path, self._conf):
                 if mode in ("w", "wb"):
                     f = azure.StreamingWriteFile(
                         self._conf, path, version, partial_writes_on_exc=partial_writes_on_exc
@@ -965,7 +971,7 @@ class Context:
             local_filename = self.basename(path)
             if local_filename == "":
                 local_filename = "local.tmp"
-            if _is_gcp_path(path) or _is_azure_path(path):
+            if _is_gcp_path(path) or _is_azure_path(path, self._conf):
                 remote_path = path
                 if mode in ("a", "ab"):
                     tmp_dir = tempfile.mkdtemp()
@@ -994,7 +1000,7 @@ class Context:
                                 assert st.version is not None
                                 remote_version = st.version
                                 remote_hash = st.md5
-                            elif _is_azure_path(path):
+                            elif _is_azure_path(path, self._conf):
                                 # in the azure case the remote md5 may not exist
                                 # this duplicates some of md5() because we want more control
                                 st = azure.maybe_stat(self._conf, path)
@@ -1034,7 +1040,7 @@ class Context:
                                     os.replace(tmp_path, local_path)
 
                                 if remote_hash is None:
-                                    if _is_azure_path(path):
+                                    if _is_azure_path(path, self._conf):
                                         azure.maybe_update_md5(
                                             self._conf, path, remote_version, local_hexdigest
                                         )
@@ -1083,11 +1089,29 @@ def _is_gcp_path(path: str) -> bool:
     return url.scheme == "gs"
 
 
-def _is_azure_path(path: str) -> bool:
+def _is_https_blob_host_candidate(hostname: str) -> bool:
+    return ".blob." in hostname
+
+
+def _is_azure_path(
+    path: str, conf: Config | None = None, *, validate_https_host: bool = True
+) -> bool:
     url = urllib.parse.urlparse(path)
-    return (
-        url.scheme == "https" and url.netloc.endswith(".blob.core.windows.net")
-    ) or url.scheme == "az"
+    if url.scheme == "az":
+        return True
+    if url.scheme != "https":
+        return False
+    hostname = url.hostname
+    if hostname is None or not _is_https_blob_host_candidate(hostname):
+        return False
+    if not validate_https_host:
+        try:
+            azure.split_https_path(path, validate=False)
+            return True
+        except Error:
+            return False
+    cloud = conf.azure_cloud if conf is not None else common.get_cloud_config()
+    return hostname.endswith(f".blob.{cloud.storage_endpoint_suffix}")
 
 
 def _is_local_path(path: str) -> bool:
@@ -1176,7 +1200,7 @@ def _split_path(path: str) -> list[str]:
     return parts
 
 
-def _expand_implicit_dirs(root: str, it: Iterator[DirEntry]) -> Iterator[DirEntry]:
+def _expand_implicit_dirs(conf: Config, root: str, it: Iterator[DirEntry]) -> Iterator[DirEntry]:
     # blob storage does not always have definitions for each intermediate dir
     # if we have a listing like
     #  gs://test/a/b
@@ -1185,8 +1209,11 @@ def _expand_implicit_dirs(root: str, it: Iterator[DirEntry]) -> Iterator[DirEntr
     # requires that iterator return objects in sorted order
     if _is_gcp_path(root):
         entry_from_dirpath = gcp.entry_from_dirpath
-    elif _is_azure_path(root):
-        entry_from_dirpath = azure.entry_from_dirpath
+    elif _is_azure_path(root, conf):
+
+        def entry_from_dirpath(path: str) -> DirEntry:
+            return azure.entry_from_dirpath(path, conf=conf)
+
     else:
         raise Error(f"Unrecognized path '{root}'")
 
@@ -1223,7 +1250,9 @@ def _glob_full(conf: Config, pattern: str) -> Iterator[DirEntry]:
 
     re_pattern = _compile_pattern(pattern)
 
-    for entry in _expand_implicit_dirs(root=prefix, it=_list_blobs(conf=conf, path=prefix)):
+    for entry in _expand_implicit_dirs(
+        conf=conf, root=prefix, it=_list_blobs(conf=conf, path=prefix)
+    ):
         entry_slash_path = _get_slash_path(entry)
         if bool(re_pattern.match(entry_slash_path)):
             if entry_slash_path == prefix and entry.is_dir:
@@ -1342,13 +1371,13 @@ def _strip_slash(path: str) -> str:
         return path
 
 
-def _guess_isdir(path: str) -> bool:
+def _guess_isdir(path: str, conf: Config | None = None) -> bool:
     """
     Guess if a path is a directory without performing network requests
     """
     if _is_local_path(path) and os.path.isdir(path):
         return True
-    elif (_is_gcp_path(path) or _is_azure_path(path)) and path.endswith("/"):
+    elif (_is_gcp_path(path) or _is_azure_path(path, conf, validate_https_host=False)) and path.endswith("/"):
         return True
     return False
 
@@ -1360,7 +1389,7 @@ def _list_blobs(conf: Config, path: str, delimiter: str | None = None) -> Iterat
 
     if _is_gcp_path(path):
         yield from gcp.list_blobs(conf, path, delimiter=delimiter)
-    elif _is_azure_path(path):
+    elif _is_azure_path(path, conf):
         yield from azure.list_blobs(conf, path, delimiter=delimiter)
     else:
         raise Error(f"Unrecognized path: '{path}'")
@@ -1372,8 +1401,8 @@ def _get_slash_path(entry: DirEntry) -> str:
 
 def _normalize_path(conf: Config, path: str) -> str:
     # convert paths to the canonical format
-    if _is_azure_path(path):
-        return azure.combine_path(conf, *azure.split_path(path))
+    if _is_azure_path(path, conf):
+        return azure.combine_path(conf, *azure.split_path(path, conf=conf))
     return path
 
 
@@ -1397,15 +1426,15 @@ def _get_entry(conf: Config, path: str) -> DirEntry | None:
                 return gcp.entry_from_path_stat(path, st)
         if ctx.isdir(path):
             return gcp.entry_from_dirpath(path)
-    elif _is_azure_path(path):
+    elif _is_azure_path(path, conf):
         st = azure.maybe_stat(conf, path)
         if st is not None:
             if path.endswith("/"):
-                return azure.entry_from_dirpath(path)
+                return azure.entry_from_dirpath(path, conf=conf)
             else:
-                return azure.entry_from_path_stat(path, st)
+                return azure.entry_from_path_stat(path, st, conf=conf)
         if ctx.isdir(path):
-            return azure.entry_from_dirpath(path)
+            return azure.entry_from_dirpath(path, conf=conf)
     else:
         raise Error(f"Unrecognized path: '{path}'")
 
@@ -1434,8 +1463,8 @@ def _join2(conf: Config, a: str, b: str) -> str:
         return os.path.join(a, b)
     elif _is_gcp_path(a):
         return gcp.join_paths(conf, a, b)
-    elif _is_azure_path(a):
-        return azure.join_paths(conf, a, b)
+    elif _is_azure_path(a, conf, validate_https_host=False):
+        return azure.join_paths(conf, a, b, validate=False)
     else:
         raise Error(f"Unrecognized path: '{a}'")
 
@@ -1541,6 +1570,7 @@ def create_context(
     get_deadline: Callable[[], float] | None = None,
     save_access_token_to_disk: bool = True,
     multiprocessing_start_method: str = "spawn",
+    _use_env_for_azure_cloud: bool = False,
 ):
     """
     Same argument as configure(), but returns a Context object that has all the blobfile methods on it.
@@ -1565,5 +1595,8 @@ def create_context(
         get_deadline=get_deadline,
         save_access_token_to_disk=save_access_token_to_disk,
         multiprocessing_start_method=multiprocessing_start_method,
+        azure_cloud_name=os.environ.get("AZURE_CLOUD"),
+        arm_cloud_metadata_url=os.environ.get("ARM_CLOUD_METADATA_URL"),
+        use_env_for_azure_cloud=_use_env_for_azure_cloud,
     )
     return Context(conf=conf)

--- a/blobfile/_ops.py
+++ b/blobfile/_ops.py
@@ -22,7 +22,9 @@ from blobfile._context import (
     default_log_fn,
 )
 
-default_context = create_context()
+# Keep the import-time default context bound to the live environment so users who
+# set Azure cloud env vars after `import blobfile` still get the expected cloud.
+default_context = create_context(_use_env_for_azure_cloud=True)
 
 
 def configure(
@@ -86,6 +88,7 @@ def configure(
         default_buffer_size=default_buffer_size,
         save_access_token_to_disk=save_access_token_to_disk,
         multiprocessing_start_method=multiprocessing_start_method,
+        _use_env_for_azure_cloud=True,
     )
 
 


### PR DESCRIPTION
Replace hardcoded public Azure endpoints with cloud-aware resolution derived from Azure cloud metadata or named cloud config. Make Azure path/auth/request handling use the active cloud, namespace Azure token caches by cloud, and avoid resolving Azure metadata for non-Azure paths.

Also align ARM_CLOUD_METADATA_URL with Azure CLI by treating it as the full metadata URL, and add regression coverage for sovereign cloud resolution and path parsing.