### PR TITLE
[codex] Honor proxy environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ There are a few bonus functions:
     * `read_timeout=30`: the maximum amount of time (in seconds) to wait between consecutive read operations for a response from the server, set to None to wait forever
     * `output_az_paths=True`: output `az://` paths instead of using the `https://` for azure
     * `use_azure_storage_account_key_fallback=False`: fallback to storage account keys for azure containers, having this enabled requires listing your subscriptions and may run into 429 errors if you hit the low azure quotas for subscription listing
-    * `get_http_pool=None`: a function that returns a `urllib3.PoolManager` to be used for requests
+    * `get_http_pool=None`: a function that returns a `urllib3.PoolManager`-compatible object to be used for requests. By default, blobfile honors standard proxy environment variables like `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`.
     * `use_streaming_read=False`: if set to `True`, use a single read per file instead of reading a chunk at a time (not recommended for azure)
     * `use_blind_writes=False`: if set to `True`, skip certain read checks during Azure writes. Defaults to checking if `BLOBFILE_USE_BLIND_WRITES` is set to `1`.
     * `default_buffer_size=io.DEFAULT_BUFFER_SIZE`: the default buffer size to use for reading files (and writing local files)

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -8,6 +8,7 @@ import ssl
 import threading
 import time
 import urllib.parse
+import urllib.request
 from types import TracebackType
 from typing import (
     Any,
@@ -264,6 +265,80 @@ class DirEntry(NamedTuple):
     stat: Stat | None
 
 
+class HttpPool(Protocol):
+    """
+    Minimal interface required for HTTP connection pools used by blobfile.
+    """
+
+    def request(self, method: str, url: str, **kwargs: Any) -> "urllib3.BaseHTTPResponse":
+        pass
+
+
+def _normalize_proxy_url(proxy_url: str) -> str:
+    if "://" in proxy_url:
+        return proxy_url
+    return f"http://{proxy_url}"
+
+
+def _create_proxy_manager(proxy_url: str, *, maxsize: int, num_pools: int) -> HttpPool:
+    proxy_url = _normalize_proxy_url(proxy_url)
+    proxy_scheme = urllib.parse.urlparse(proxy_url).scheme.lower()
+    if proxy_scheme.startswith("socks"):
+        from urllib3.contrib.socks import SOCKSProxyManager
+
+        return SOCKSProxyManager(proxy_url, maxsize=maxsize, num_pools=num_pools)
+    return urllib3.ProxyManager(proxy_url, maxsize=maxsize, num_pools=num_pools)
+
+
+class ProxyAwarePoolManager:
+    """
+    Pool manager that follows standard proxy environment variables.
+
+    urllib3.PoolManager intentionally makes direct connections and does not read
+    HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, or NO_PROXY on its own. This wrapper
+    keeps direct pooling as the default, but routes through cached ProxyManager
+    instances when urllib.request reports a proxy for the request scheme.
+    """
+
+    def __init__(self, connection_pool_max_size: int, max_connection_pool_count: int) -> None:
+        self.connection_pool_max_size = connection_pool_max_size
+        self.max_connection_pool_count = max_connection_pool_count
+        self.direct_pool = urllib3.PoolManager(
+            maxsize=connection_pool_max_size, num_pools=max_connection_pool_count
+        )
+        self.proxy_pools: dict[str, HttpPool] = {}
+        self.lock = threading.Lock()
+
+    def request(self, method: str, url: str, **kwargs: Any) -> "urllib3.BaseHTTPResponse":
+        pool = self._pool_for_url(url)
+        return pool.request(method, url, **kwargs)
+
+    def _pool_for_url(self, url: str) -> HttpPool:
+        parsed = urllib.parse.urlparse(url)
+        proxies = urllib.request.getproxies()
+        host = parsed.netloc.rsplit("@", 1)[-1]
+        if not parsed.scheme or not host:
+            return self.direct_pool
+        if urllib.request.proxy_bypass_environment(host, proxies):
+            return self.direct_pool
+
+        proxy_url = proxies.get(parsed.scheme) or proxies.get("all")
+        if proxy_url is None:
+            return self.direct_pool
+        proxy_url = _normalize_proxy_url(proxy_url)
+
+        with self.lock:
+            proxy_pool = self.proxy_pools.get(proxy_url)
+            if proxy_pool is None:
+                proxy_pool = _create_proxy_manager(
+                    proxy_url,
+                    maxsize=self.connection_pool_max_size,
+                    num_pools=self.max_connection_pool_count,
+                )
+                self.proxy_pools[proxy_url] = proxy_pool
+            return proxy_pool
+
+
 class PoolDirector:
     def __init__(self, connection_pool_max_size: int, max_connection_pool_count: int) -> None:
         self.connection_pool_max_size = connection_pool_max_size
@@ -272,18 +347,17 @@ class PoolDirector:
         self.creation_pid = None
         self.lock = threading.Lock()
 
-    def get_http_pool(self) -> urllib3.PoolManager:
+    def get_http_pool(self) -> HttpPool:
         # ssl is not fork safe https://docs.python.org/2/library/ssl.html#multi-processing
         # urllib3 may not be fork safe https://github.com/urllib3/urllib3/issues/1179
         # both are supposedly threadsafe though, so we shouldn't need a thread-local pool
         with self.lock:
             if self.pool_manager is None or self.creation_pid != os.getpid():
                 self.creation_pid = os.getpid()
-                self.pool_manager = urllib3.PoolManager(
-                    maxsize=self.connection_pool_max_size, num_pools=self.max_connection_pool_count
+                self.pool_manager = ProxyAwarePoolManager(
+                    connection_pool_max_size=self.connection_pool_max_size,
+                    max_connection_pool_count=self.max_connection_pool_count,
                 )
-                # for debugging with mitmproxy
-                # self.http = urllib3.ProxyManager('http://localhost:8080/', ssl_context=context)
             return self.pool_manager
 
     # we don't want to serialize locks or other unpicklable objects
@@ -323,7 +397,7 @@ class Config:
         read_timeout: int | None,
         output_az_paths: bool,
         use_azure_storage_account_key_fallback: bool,
-        get_http_pool: Callable[[], urllib3.PoolManager] | None,
+        get_http_pool: Callable[[], HttpPool] | None,
         use_streaming_read: bool,
         use_blind_writes: bool,
         default_buffer_size: int,
@@ -360,7 +434,7 @@ class Config:
                 )
         self._get_http_pool = get_http_pool
 
-    def get_http_pool(self) -> urllib3.PoolManager:
+    def get_http_pool(self) -> HttpPool:
         if self._get_http_pool is None:
             return global_pool_director.get_http_pool()
         else:

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -33,7 +33,6 @@ from typing import (
 )
 
 import filelock
-import urllib3
 
 from blobfile import _azure as azure
 from blobfile import _common as common
@@ -45,6 +44,7 @@ from blobfile._common import (
     Config,
     DirEntry,
     Error,
+    HttpPool,
     RemoteOrLocalPath,
     Request,
     RestartableStreamingWriteFailure,
@@ -1534,7 +1534,7 @@ def create_context(
     read_timeout: int | None = DEFAULT_READ_TIMEOUT,
     output_az_paths: bool = True,
     use_azure_storage_account_key_fallback: bool = False,
-    get_http_pool: Callable[[], urllib3.PoolManager] | None = None,
+    get_http_pool: Callable[[], HttpPool] | None = None,
     use_streaming_read: bool = False,
     use_blind_writes: bool = DEFAULT_USE_BLIND_WRITES,
     default_buffer_size: int = DEFAULT_BUFFER_SIZE,

--- a/blobfile/_ops.py
+++ b/blobfile/_ops.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 import concurrent.futures
 from typing import BinaryIO, Callable, Iterator, Literal, Sequence, TextIO, overload
 
-import urllib3
-
-from blobfile._common import DirEntry, RemoteOrLocalPath, Stat
+from blobfile._common import DirEntry, HttpPool, RemoteOrLocalPath, Stat
 from blobfile._context import (
     DEFAULT_AZURE_WRITE_CHUNK_SIZE,
     DEFAULT_BUFFER_SIZE,
@@ -41,7 +39,7 @@ def configure(
     read_timeout: int | None = DEFAULT_READ_TIMEOUT,
     output_az_paths: bool = True,
     use_azure_storage_account_key_fallback: bool = False,
-    get_http_pool: Callable[[], urllib3.PoolManager] | None = None,
+    get_http_pool: Callable[[], HttpPool] | None = None,
     use_streaming_read: bool = False,
     use_blind_writes: bool = DEFAULT_USE_BLIND_WRITES,
     default_buffer_size: int = DEFAULT_BUFFER_SIZE,
@@ -59,7 +57,9 @@ def configure(
     read_timeout: the maximum amount of time (in seconds) to wait between consecutive read operations for a response from the server, set to None to wait forever
     output_az_paths: output `az://` paths instead of using the `https://` for azure
     use_azure_storage_account_key_fallback: fallback to storage account keys for azure containers, having this enabled requires listing your subscriptions and may run into 429 errors if you hit the low azure quotas for subscription listing
-    get_http_pool: a function that returns a `urllib3.PoolManager` to be used for requests
+    get_http_pool: a function that returns a `urllib3.PoolManager`-compatible object to be used
+    for requests. By default, blobfile honors standard proxy environment variables such as
+    HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, and NO_PROXY.
     use_streaming_read: if set to `True`, use a single read per file instead of reading a chunk at a time (not recommended for azure)
     use_blind_writes: if set to `True`, skip certain read checks during Azure writes
     default_buffer_size: the default buffer size to use for reading files (and writing local files)

--- a/blobfile/_ops_test.py
+++ b/blobfile/_ops_test.py
@@ -1593,6 +1593,133 @@ def test_fork():
     assert child != parent1
 
 
+class _FakeHttpPool:
+    def __init__(self, name):
+        self.name = name
+        self.requests = []
+
+    def request(self, method, url, **kwargs):
+        self.requests.append((method, url, kwargs))
+        return self.name
+
+
+def test_default_http_pool_honors_https_proxy():
+    direct_pool = _FakeHttpPool("direct")
+    proxy_pools = {}
+    proxy_manager_calls = []
+
+    def pool_manager(**kwargs):
+        assert kwargs == {"maxsize": 3, "num_pools": 4}
+        return direct_pool
+
+    def proxy_manager(proxy_url, **kwargs):
+        assert kwargs == {"maxsize": 3, "num_pools": 4}
+        proxy_manager_calls.append(proxy_url)
+        proxy_pool = _FakeHttpPool(proxy_url)
+        proxy_pools[proxy_url] = proxy_pool
+        return proxy_pool
+
+    director = common.PoolDirector(connection_pool_max_size=3, max_connection_pool_count=4)
+    with (
+        unittest.mock.patch("blobfile._common.urllib3.PoolManager", side_effect=pool_manager),
+        unittest.mock.patch("blobfile._common.urllib3.ProxyManager", side_effect=proxy_manager),
+        unittest.mock.patch(
+            "blobfile._common.urllib.request.getproxies",
+            return_value={"https": "http://proxy.example:3128"},
+        ),
+    ):
+        pool = director.get_http_pool()
+        assert pool.request("GET", "https://storage.googleapis.com/bucket") == (
+            "http://proxy.example:3128"
+        )
+        assert pool.request("HEAD", "https://example.blob.core.windows.net/container") == (
+            "http://proxy.example:3128"
+        )
+
+    assert direct_pool.requests == []
+    assert proxy_manager_calls == ["http://proxy.example:3128"]
+    assert proxy_pools["http://proxy.example:3128"].requests == [
+        ("GET", "https://storage.googleapis.com/bucket", {}),
+        ("HEAD", "https://example.blob.core.windows.net/container", {}),
+    ]
+
+
+def test_default_http_pool_respects_no_proxy():
+    direct_pool = _FakeHttpPool("direct")
+
+    def pool_manager(**kwargs):
+        return direct_pool
+
+    def proxy_manager(proxy_url, **kwargs):
+        raise AssertionError(f"unexpected proxy manager for {proxy_url}")
+
+    director = common.PoolDirector(connection_pool_max_size=3, max_connection_pool_count=4)
+    with (
+        unittest.mock.patch("blobfile._common.urllib3.PoolManager", side_effect=pool_manager),
+        unittest.mock.patch("blobfile._common.urllib3.ProxyManager", side_effect=proxy_manager),
+        unittest.mock.patch(
+            "blobfile._common.urllib.request.getproxies",
+            return_value={"https": "http://proxy.example:3128", "no": "storage.googleapis.com"},
+        ),
+    ):
+        pool = director.get_http_pool()
+        assert pool.request("GET", "https://storage.googleapis.com/bucket") == "direct"
+
+    assert direct_pool.requests == [("GET", "https://storage.googleapis.com/bucket", {})]
+
+
+def test_default_http_pool_accepts_proxy_without_scheme():
+    proxy_manager_calls = []
+
+    def proxy_manager(proxy_url, **kwargs):
+        proxy_manager_calls.append(proxy_url)
+        return _FakeHttpPool(proxy_url)
+
+    director = common.PoolDirector(connection_pool_max_size=3, max_connection_pool_count=4)
+    with (
+        unittest.mock.patch(
+            "blobfile._common.urllib3.PoolManager", return_value=_FakeHttpPool("direct")
+        ),
+        unittest.mock.patch("blobfile._common.urllib3.ProxyManager", side_effect=proxy_manager),
+        unittest.mock.patch(
+            "blobfile._common.urllib.request.getproxies",
+            return_value={"https": "proxy.example:3128"},
+        ),
+    ):
+        pool = director.get_http_pool()
+        assert pool.request("GET", "https://storage.googleapis.com/bucket") == (
+            "http://proxy.example:3128"
+        )
+
+    assert proxy_manager_calls == ["http://proxy.example:3128"]
+
+
+def test_default_http_pool_uses_all_proxy_fallback():
+    proxy_manager_calls = []
+
+    def proxy_manager(proxy_url, **kwargs):
+        proxy_manager_calls.append(proxy_url)
+        return _FakeHttpPool(proxy_url)
+
+    director = common.PoolDirector(connection_pool_max_size=3, max_connection_pool_count=4)
+    with (
+        unittest.mock.patch(
+            "blobfile._common.urllib3.PoolManager", return_value=_FakeHttpPool("direct")
+        ),
+        unittest.mock.patch("blobfile._common.urllib3.ProxyManager", side_effect=proxy_manager),
+        unittest.mock.patch(
+            "blobfile._common.urllib.request.getproxies",
+            return_value={"all": "http://proxy.example:3128"},
+        ),
+    ):
+        pool = director.get_http_pool()
+        assert pool.request("GET", "https://storage.googleapis.com/bucket") == (
+            "http://proxy.example:3128"
+        )
+
+    assert proxy_manager_calls == ["http://proxy.example:3128"]
+
+
 def test_azure_public_container():
     for error, path in [
         (None, f"https://{AS_EXTERNAL_ACCOUNT}.blob.core.windows.net/publiccontainer/test_cat.png"),


### PR DESCRIPTION
## Summary
- add a proxy-aware default HTTP pool that honors HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, and NO_PROXY
- preserve the custom get_http_pool hook by typing it as any PoolManager-compatible object
- document the default proxy behavior and add focused tests for proxy routing and bypasses

## Root cause
blobfile's default transport used urllib3.PoolManager directly. urllib3 does not read standard proxy environment variables for PoolManager, so proxy-only environments attempt direct egress and can fail before blobfile reaches cloud auth or storage endpoints.

## Validation
- python3 -m black blobfile/_common.py blobfile/_ops.py blobfile/_context.py blobfile/_ops_test.py
- python3 -m pytest blobfile/_ops_test.py -k "default_http_pool or fork or pickle_config"
- python3 -m compileall -q blobfile
- git diff --check