### PR TITLE
Refresh retry connection after repeated HTTP failures

### DIFF
--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -41,6 +41,7 @@ INVALID_HOSTNAME_STATUS = 600  # fake status for invalid hostname
 
 BACKOFF_INITIAL = 0.1
 BACKOFF_MAX = 60.0
+RETRYABLE_HTTP_FAILURES_BEFORE_CONNECTION_REFRESH = 10
 
 HOSTNAME_EXISTS = 0
 HOSTNAME_DOES_NOT_EXIST = 1
@@ -477,8 +478,22 @@ def _read_with_deadline(
 
 
 def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.BaseHTTPResponse":
+    retryable_http_failures = 0
     for attempt, backoff in enumerate(exponential_sleep_generator()):
         req = build_req()
+        close_connection_for_this_attempt = (
+            retryable_http_failures == RETRYABLE_HTTP_FAILURES_BEFORE_CONNECTION_REFRESH - 1
+        )
+        request_headers = req.headers
+        if close_connection_for_this_attempt:
+            request_headers = {}
+            if req.headers is not None:
+                request_headers = {
+                    name: value
+                    for name, value in req.headers.items()
+                    if name.lower() != "connection"
+                }
+            request_headers["Connection"] = "close"
         url = req.url
         if req.params is not None:
             if len(req.params) > 0:
@@ -533,7 +548,7 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
             resp = conf.get_http_pool().request(
                 method=req.method,
                 url=url,
-                headers=req.headers,
+                headers=request_headers,
                 # WindowedFile isn't actually an IO[Any] or Iterable[bytes]
                 body=body,  # type: ignore
                 timeout=urllib3.Timeout(
@@ -594,6 +609,7 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
                 )
                 if resp.status not in req.retry_codes:
                     raise err
+                retryable_http_failures += 1
         except (
             urllib3.exceptions.ConnectTimeoutError,
             urllib3.exceptions.ReadTimeoutError,
@@ -644,6 +660,9 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
 
         if conf.retry_limit is not None and attempt >= conf.retry_limit:
             raise err
+
+        if close_connection_for_this_attempt:
+            retryable_http_failures = 0
 
         if attempt >= get_log_threshold_for_error(conf, str(err)):
             conf.log_callback(

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -662,6 +662,7 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
             raise err
 
         if close_connection_for_this_attempt:
+            conf.get_http_pool().clear()
             retryable_http_failures = 0
 
         if attempt >= get_log_threshold_for_error(conf, str(err)):

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -920,7 +920,7 @@ class BaseStreamingReadFile(io.RawIOBase):
                 err = None
                 try:
                     # urllib3 should actually admit a memoryview over here
-                    opt_n = self._f.readinto(b)  # type: ignore
+                    opt_n = self._f.readinto(b)
                     assert opt_n is not None, "file is in non-blocking mode"
                     n = opt_n
                     if n == 0:

--- a/blobfile/_ops_test.py
+++ b/blobfile/_ops_test.py
@@ -11,10 +11,12 @@ import re
 import string
 import subprocess as sp
 import tempfile
+import threading
 import time
 import unittest.mock
 import urllib.request
 import zipfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import numpy as np
 import pytest
@@ -1706,12 +1708,59 @@ def test_retryable_http_failures_periodically_refresh_connection():
 
     assert resp.status == 200
     assert pool.request.call_count == 21
+    assert pool.clear.call_count == 2
     assert request_headers[8] is None
     assert request_headers[9] == {"Connection": "close"}
     assert request_headers[18] is None
     assert request_headers[19] == {"Connection": "close"}
     assert request_headers[20] is None
     assert req.headers is None
+
+
+def test_retryable_http_failures_refresh_underlying_pool_connection():
+    seen_ports = []
+    request_ports = []
+
+    class StickyConnectionHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_HEAD(self):
+            client_port = self.client_address[1]
+            request_ports.append(client_port)
+            if client_port not in seen_ports:
+                seen_ports.append(client_port)
+
+            self.send_response(503 if len(seen_ports) == 1 else 200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            self.close_connection = False
+
+        def log_message(self, format, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), StickyConnectionHandler)
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        pool = urllib3.PoolManager()
+        ctx = bf.create_context(get_http_pool=lambda: pool, retry_limit=10)
+        req = common.Request(
+            method="HEAD", url=f"http://127.0.0.1:{server.server_port}/blob", success_codes=(200,)
+        )
+
+        with unittest.mock.patch("blobfile._common.time.sleep"):
+            resp = common.execute_request(ctx._conf, lambda: req)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+    assert resp.status == 200
+    assert len(seen_ports) == 2
+    assert request_ports[:10] == [seen_ports[0]] * 10
+    assert request_ports[10] == seen_ports[1]
 
 
 @pytest.mark.parametrize("ctx", [_get_temp_gcs_path, _get_temp_as_path])

--- a/blobfile/_ops_test.py
+++ b/blobfile/_ops_test.py
@@ -18,6 +18,7 @@ import zipfile
 
 import numpy as np
 import pytest
+import urllib3
 
 import blobfile as bf
 from blobfile import _azure as azure
@@ -1685,6 +1686,32 @@ def test_pickle_config():
     c.get_http_pool()
     c2 = pickle.loads(pickle.dumps(c))
     c2.get_http_pool()
+
+
+def test_retryable_http_failures_periodically_refresh_connection():
+    statuses = [503] * 20 + [200]
+    request_headers = []
+
+    def request(**kwargs):
+        request_headers.append(kwargs["headers"])
+        return urllib3.response.HTTPResponse(status=statuses.pop(0), body=b"")
+
+    pool = unittest.mock.Mock()
+    pool.request.side_effect = request
+    ctx = bf.create_context(get_http_pool=lambda: pool, retry_limit=20)
+    req = common.Request(method="HEAD", url="https://example.com/blob", success_codes=(200,))
+
+    with unittest.mock.patch("blobfile._common.time.sleep"):
+        resp = common.execute_request(ctx._conf, lambda: req)
+
+    assert resp.status == 200
+    assert pool.request.call_count == 21
+    assert request_headers[8] is None
+    assert request_headers[9] == {"Connection": "close"}
+    assert request_headers[18] is None
+    assert request_headers[19] == {"Connection": "close"}
+    assert request_headers[20] is None
+    assert req.headers is None
 
 
 @pytest.mark.parametrize("ctx", [_get_temp_gcs_path, _get_temp_as_path])

--- a/blobfile/_ops_test.py
+++ b/blobfile/_ops_test.py
@@ -1736,6 +1736,7 @@ def test_retryable_http_failures_refresh_underlying_pool_connection():
             self.close_connection = False
 
         def log_message(self, format, *args):
+            # Keep the test output quiet when the local HTTP server handles retries.
             pass
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), StickyConnectionHandler)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,8 +1,7 @@
 {
     "venv": "blobfile",
     "include": [
-        "blobfile",
-        "setup.py"
+        "blobfile"
     ],
     "exclude": [
         "blobfile/**/*_test.py",
@@ -51,7 +50,6 @@
     "reportUntypedNamedTuple": "error",
     "reportCallInDefaultInitializer": "error",
     "reportPropertyTypeMismatch": "error",
-    "reportShadowedImports": "error",
     "reportUninitializedInstanceVariable": "error",
     "reportUnnecessaryTypeIgnoreComment": "error",
 }


### PR DESCRIPTION
## Description
- This change makes the retry-refresh path actually force a fresh client-side connection after repeated retryable HTTP failures.
- After the refresh attempt fires, blobfile now clears the active urllib3.PoolManager. That evicts cached pools so the next retry cannot reuse the same stale connection and must lazily recreate the pool and open a new TCP connection.
- also clean up stale pyright checks
```
  Run pyright
  Config contains unrecognized setting "reportShadowedImports".
  File or directory "/home/runner/work/blobfile/blobfile/setup.py" does not exist.
  ...
```

## Testing
- Added coverage for both the control flow and the real socket behavior:
-  I also manually reproduced the behavior locally with a small urllib3.PoolManager script and a local HTTP server:
  - The server returned 503 for requests on the first TCP connection and 200 only after a new connection was opened.
  - In the version where the server honored Connection: close, the next request moved to a new connection and succeeded.
  - In the sticky case where the server deliberately kept the first socket open despite Connection: close, urllib3 kept reusing that same socket and all retries remained on the failing connection.
  - That confirmed the header alone was insufficient and that we needed local pool invalidation.